### PR TITLE
Added units for PIC mid-range models

### DIFF
--- a/PIC10F320.pas
+++ b/PIC10F320.pas
@@ -1,0 +1,465 @@
+unit PIC10F320;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F320'}
+{$SET PIC_MAXFREQ  = 16000000}
+{$SET PIC_NPINS    = 6}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 256}
+
+interface
+var
+  INDF                : byte absolute $0000;
+  TMR0                : byte absolute $0001;
+  PCL                 : byte absolute $0002;
+  STATUS              : byte absolute $0003;
+  STATUS_IRP          : bit  absolute STATUS.7;
+  STATUS_RP1          : bit  absolute STATUS.6;
+  STATUS_RP0          : bit  absolute STATUS.5;
+  STATUS_TO           : bit  absolute STATUS.4;
+  STATUS_PD           : bit  absolute STATUS.3;
+  STATUS_Z            : bit  absolute STATUS.2;
+  STATUS_DC           : bit  absolute STATUS.1;
+  STATUS_C            : bit  absolute STATUS.0;
+  FSR                 : byte absolute $0004;
+  PORTA               : byte absolute $0005;
+  PORTA_RA3           : bit  absolute PORTA.4;
+  PORTA_RA2           : bit  absolute PORTA.3;
+  PORTA_RA1           : bit  absolute PORTA.2;
+  PORTA_RA0           : bit  absolute PORTA.1;
+  TRISA               : byte absolute $0006;
+  TRISA_TRISA2        : bit  absolute TRISA.3;
+  TRISA_TRISA1        : bit  absolute TRISA.2;
+  TRISA_TRISA0        : bit  absolute TRISA.1;
+  LATA                : byte absolute $0007;
+  LATA_LATA2          : bit  absolute LATA.2;
+  LATA_LATA1          : bit  absolute LATA.1;
+  LATA_LATA0          : bit  absolute LATA.0;
+  ANSELA              : byte absolute $0008;
+  ANSELA_ANSA2        : bit  absolute ANSELA.2;
+  ANSELA_ANSA1        : bit  absolute ANSELA.1;
+  ANSELA_ANSA0        : bit  absolute ANSELA.0;
+  WPUA                : byte absolute $0009;
+  WPUA_WPUA3          : bit  absolute WPUA.3;
+  WPUA_WPUA2          : bit  absolute WPUA.2;
+  WPUA_WPUA1          : bit  absolute WPUA.1;
+  WPUA_WPUA0          : bit  absolute WPUA.0;
+  PCLATH              : byte absolute $000a;
+  PCLATH_PCLH0        : bit  absolute PCLATH.4;
+  INTCON              : byte absolute $000b;
+  INTCON_GIE          : bit  absolute INTCON.7;
+  INTCON_PEIE         : bit  absolute INTCON.6;
+  INTCON_TMR0IE       : bit  absolute INTCON.5;
+  INTCON_INTE         : bit  absolute INTCON.4;
+  INTCON_IOCIE        : bit  absolute INTCON.3;
+  INTCON_TMR0IF       : bit  absolute INTCON.2;
+  INTCON_INTF         : bit  absolute INTCON.1;
+  INTCON_IOCIF        : bit  absolute INTCON.0;
+  PIR1                : byte absolute $000c;
+  PIR1_ADIF           : bit  absolute PIR1.4;
+  PIR1_NCO1IF         : bit  absolute PIR1.3;
+  PIR1_CLC1IF         : bit  absolute PIR1.2;
+  PIR1_TMR2IF         : bit  absolute PIR1.1;
+  PIE1                : byte absolute $000d;
+  PIE1_ADIE           : bit  absolute PIE1.4;
+  PIE1_NCO1IE         : bit  absolute PIE1.3;
+  PIE1_CLC1IE         : bit  absolute PIE1.2;
+  PIE1_TMR2IE         : bit  absolute PIE1.1;
+  OPTION_REG          : byte absolute $000e;
+  OPTION_REG_WPUEN    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG   : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS     : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE     : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA      : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2      : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1      : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0      : bit  absolute OPTION_REG.0;
+  PCON                : byte absolute $000f;
+  PCON_POR            : bit  absolute PCON.1;
+  PCON_BOR            : bit  absolute PCON.0;
+  OSCCON              : byte absolute $0010;
+  OSCCON_IRCF2        : bit  absolute OSCCON.6;
+  OSCCON_IRCF1        : bit  absolute OSCCON.5;
+  OSCCON_IRCF0        : bit  absolute OSCCON.4;
+  OSCCON_HFIOFR       : bit  absolute OSCCON.3;
+  OSCCON_LFIOFR       : bit  absolute OSCCON.2;
+  OSCCON_HFIOFS       : bit  absolute OSCCON.1;
+  TMR2                : byte absolute $0011;
+  PR2                 : byte absolute $0012;
+  T2CON               : byte absolute $0013;
+  T2CON_TOUTPS3       : bit  absolute T2CON.6;
+  T2CON_TOUTPS2       : bit  absolute T2CON.5;
+  T2CON_TOUTPS1       : bit  absolute T2CON.4;
+  T2CON_TOUTPS0       : bit  absolute T2CON.3;
+  T2CON_TMR2ON        : bit  absolute T2CON.2;
+  T2CON_T2CKPS0       : bit  absolute T2CON.1;
+  PWM1DCL             : byte absolute $0014;
+  PWM1DCL_PWM1DCL1    : bit  absolute PWM1DCL.2;
+  PWM1DCL_PWM1DCL0    : bit  absolute PWM1DCL.1;
+  PWM1DCH             : byte absolute $0015;
+  PWM1DCH_PWM1DCH7    : bit  absolute PWM1DCH.7;
+  PWM1DCH_PWM1DCH6    : bit  absolute PWM1DCH.6;
+  PWM1DCH_PWM1DCH5    : bit  absolute PWM1DCH.5;
+  PWM1DCH_PWM1DCH4    : bit  absolute PWM1DCH.4;
+  PWM1DCH_PWM1DCH3    : bit  absolute PWM1DCH.3;
+  PWM1DCH_PWM1DCH2    : bit  absolute PWM1DCH.2;
+  PWM1DCH_PWM1DCH1    : bit  absolute PWM1DCH.1;
+  PWM1DCH_PWM1DCH0    : bit  absolute PWM1DCH.0;
+  PWM1CON             : byte absolute $0016;
+  PWM1CON_PWM1EN      : bit  absolute PWM1CON.4;
+  PWM1CON_PWM1OE      : bit  absolute PWM1CON.3;
+  PWM1CON_PWM1OUT     : bit  absolute PWM1CON.2;
+  PWM1CON_PWM1POL     : bit  absolute PWM1CON.1;
+  PWM2DCL             : byte absolute $0017;
+  PWM2DCL_PWM2DCL1    : bit  absolute PWM2DCL.2;
+  PWM2DCL_PWM2DCL0    : bit  absolute PWM2DCL.1;
+  PWM2DCH             : byte absolute $0018;
+  PWM2DCH_PWM2DCH7    : bit  absolute PWM2DCH.7;
+  PWM2DCH_PWM2DCH6    : bit  absolute PWM2DCH.6;
+  PWM2DCH_PWM2DCH5    : bit  absolute PWM2DCH.5;
+  PWM2DCH_PWM2DCH4    : bit  absolute PWM2DCH.4;
+  PWM2DCH_PWM2DCH3    : bit  absolute PWM2DCH.3;
+  PWM2DCH_PWM2DCH2    : bit  absolute PWM2DCH.2;
+  PWM2DCH_PWM2DCH1    : bit  absolute PWM2DCH.1;
+  PWM2DCH_PWM2DCH0    : bit  absolute PWM2DCH.0;
+  PWM2CON             : byte absolute $0019;
+  PWM2CON_PWM2EN      : bit  absolute PWM2CON.4;
+  PWM2CON_PWM2OE      : bit  absolute PWM2CON.3;
+  PWM2CON_PWM2OUT     : bit  absolute PWM2CON.2;
+  PWM2CON_PWM2POL     : bit  absolute PWM2CON.1;
+  IOCAP               : byte absolute $001a;
+  IOCAP_IOCAP3        : bit  absolute IOCAP.6;
+  IOCAP_IOCAP2        : bit  absolute IOCAP.5;
+  IOCAP_IOCAP1        : bit  absolute IOCAP.4;
+  IOCAP_IOCAP0        : bit  absolute IOCAP.3;
+  IOCAN               : byte absolute $001b;
+  IOCAN_IOCAN3        : bit  absolute IOCAN.4;
+  IOCAN_IOCAN2        : bit  absolute IOCAN.3;
+  IOCAN_IOCAN1        : bit  absolute IOCAN.2;
+  IOCAN_IOCAN0        : bit  absolute IOCAN.1;
+  IOCAF               : byte absolute $001c;
+  IOCAF_IOCAF3        : bit  absolute IOCAF.4;
+  IOCAF_IOCAF2        : bit  absolute IOCAF.3;
+  IOCAF_IOCAF1        : bit  absolute IOCAF.2;
+  IOCAF_IOCAF0        : bit  absolute IOCAF.1;
+  FVRCON              : byte absolute $001d;
+  FVRCON_FVREN        : bit  absolute FVRCON.6;
+  FVRCON_FVRRDY       : bit  absolute FVRCON.5;
+  FVRCON_TSEN         : bit  absolute FVRCON.4;
+  FVRCON_TSRNG        : bit  absolute FVRCON.3;
+  FVRCON_ADFVR1       : bit  absolute FVRCON.1;
+  FVRCON_ADFVR0       : bit  absolute FVRCON.0;
+  ADRES               : byte absolute $001e;
+  ADCON               : byte absolute $001f;
+  ADCON_ADCS2         : bit  absolute ADCON.7;
+  ADCON_ADCS1         : bit  absolute ADCON.6;
+  ADCON_ADCS0         : bit  absolute ADCON.5;
+  ADCON_CHS2          : bit  absolute ADCON.4;
+  ADCON_CHS1          : bit  absolute ADCON.3;
+  ADCON_CHS0          : bit  absolute ADCON.2;
+  ADCON_GO_nDONE      : bit  absolute ADCON.1;
+  ADCON_ADON          : bit  absolute ADCON.0;
+  PMADRL              : byte absolute $0020;
+  PMADRH              : byte absolute $0021;
+  PMADRH_PMADR8       : bit  absolute PMADRH.3;
+  PMDATL              : byte absolute $0022;
+  PMDATH              : byte absolute $0023;
+  PMCON1              : byte absolute $0024;
+  PMCON1_CFGS         : bit  absolute PMCON1.6;
+  PMCON1_LWLO         : bit  absolute PMCON1.5;
+  PMCON1_FREE         : bit  absolute PMCON1.4;
+  PMCON1_WRERR        : bit  absolute PMCON1.3;
+  PMCON1_WREN         : bit  absolute PMCON1.2;
+  PMCON1_WR           : bit  absolute PMCON1.1;
+  PMCON1_RD           : bit  absolute PMCON1.0;
+  PMCON2              : byte absolute $0025;
+  CLKRCON             : byte absolute $0026;
+  CLKRCON_CLKROE      : bit  absolute CLKRCON.6;
+  NCO1ACCL            : byte absolute $0027;
+  NCO1ACCL_NCO1ACC7   : bit  absolute NCO1ACCL.7;
+  NCO1ACCL_NCO1ACC6   : bit  absolute NCO1ACCL.6;
+  NCO1ACCL_NCO1ACC5   : bit  absolute NCO1ACCL.5;
+  NCO1ACCL_NCO1ACC4   : bit  absolute NCO1ACCL.4;
+  NCO1ACCL_NCO1ACC3   : bit  absolute NCO1ACCL.3;
+  NCO1ACCL_NCO1ACC2   : bit  absolute NCO1ACCL.2;
+  NCO1ACCL_NCO1ACC1   : bit  absolute NCO1ACCL.1;
+  NCO1ACCL_NCO1ACC0   : bit  absolute NCO1ACCL.0;
+  NCO1ACCH            : byte absolute $0028;
+  NCO1ACCH_NCO1ACC15  : bit  absolute NCO1ACCH.7;
+  NCO1ACCH_NCO1ACC14  : bit  absolute NCO1ACCH.6;
+  NCO1ACCH_NCO1ACC13  : bit  absolute NCO1ACCH.5;
+  NCO1ACCH_NCO1ACC12  : bit  absolute NCO1ACCH.4;
+  NCO1ACCH_NCO1ACC11  : bit  absolute NCO1ACCH.3;
+  NCO1ACCH_NCO1ACC10  : bit  absolute NCO1ACCH.2;
+  NCO1ACCH_NCO1ACC9   : bit  absolute NCO1ACCH.1;
+  NCO1ACCH_NCO1ACC8   : bit  absolute NCO1ACCH.0;
+  NCO1ACCU            : byte absolute $0029;
+  NCO1ACCU_NCO1ACC19  : bit  absolute NCO1ACCU.4;
+  NCO1ACCU_NCO1ACC18  : bit  absolute NCO1ACCU.3;
+  NCO1ACCU_NCO1ACC17  : bit  absolute NCO1ACCU.2;
+  NCO1ACCU_NCO1ACC16  : bit  absolute NCO1ACCU.1;
+  NCO1INCL            : byte absolute $002a;
+  NCO1INCL_NCO1INC7   : bit  absolute NCO1INCL.7;
+  NCO1INCL_NCO1INC6   : bit  absolute NCO1INCL.6;
+  NCO1INCL_NCO1INC5   : bit  absolute NCO1INCL.5;
+  NCO1INCL_NCO1INC4   : bit  absolute NCO1INCL.4;
+  NCO1INCL_NCO1INC3   : bit  absolute NCO1INCL.3;
+  NCO1INCL_NCO1INC2   : bit  absolute NCO1INCL.2;
+  NCO1INCL_NCO1INC1   : bit  absolute NCO1INCL.1;
+  NCO1INCL_NCO1INC0   : bit  absolute NCO1INCL.0;
+  NCO1INCH            : byte absolute $002b;
+  NCO1INCH_NCO1INC15  : bit  absolute NCO1INCH.7;
+  NCO1INCH_NCO1INC14  : bit  absolute NCO1INCH.6;
+  NCO1INCH_NCO1INC13  : bit  absolute NCO1INCH.5;
+  NCO1INCH_NCO1INC12  : bit  absolute NCO1INCH.4;
+  NCO1INCH_NCO1INC11  : bit  absolute NCO1INCH.3;
+  NCO1INCH_NCO1INC10  : bit  absolute NCO1INCH.2;
+  NCO1INCH_NCO1INC9   : bit  absolute NCO1INCH.1;
+  NCO1INCH_NCO1INC8   : bit  absolute NCO1INCH.0;
+  NCO1INCU            : byte absolute $002c;
+  NCO1CON             : byte absolute $002d;
+  NCO1CON_N1EN        : bit  absolute NCO1CON.5;
+  NCO1CON_N1OE        : bit  absolute NCO1CON.4;
+  NCO1CON_N1OUT       : bit  absolute NCO1CON.3;
+  NCO1CON_N1POL       : bit  absolute NCO1CON.2;
+  NCO1CON_N1PFM       : bit  absolute NCO1CON.1;
+  NCO1CLK             : byte absolute $002e;
+  NCO1CLK_N1PWS2      : bit  absolute NCO1CLK.5;
+  NCO1CLK_N1PWS1      : bit  absolute NCO1CLK.4;
+  NCO1CLK_N1PWS0      : bit  absolute NCO1CLK.3;
+  NCO1CLK_N1CKS1      : bit  absolute NCO1CLK.2;
+  NCO1CLK_N1CKS0      : bit  absolute NCO1CLK.1;
+  WDTCON              : byte absolute $0030;
+  WDTCON_WDTPS4       : bit  absolute WDTCON.5;
+  WDTCON_WDTPS3       : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2       : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1       : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0       : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN       : bit  absolute WDTCON.0;
+  CLC1CON             : byte absolute $0031;
+  CLC1CON_LC1EN       : bit  absolute CLC1CON.7;
+  CLC1CON_LC1OE       : bit  absolute CLC1CON.6;
+  CLC1CON_LC1OUT      : bit  absolute CLC1CON.5;
+  CLC1CON_LC1INTP     : bit  absolute CLC1CON.4;
+  CLC1CON_LC1INTN     : bit  absolute CLC1CON.3;
+  CLC1CON_LC1MODE2    : bit  absolute CLC1CON.2;
+  CLC1CON_LC1MODE1    : bit  absolute CLC1CON.1;
+  CLC1CON_LC1MODE0    : bit  absolute CLC1CON.0;
+  CLC1SEL0            : byte absolute $0032;
+  CLC1SEL0_LC1D2S2    : bit  absolute CLC1SEL0.6;
+  CLC1SEL0_LC1D2S1    : bit  absolute CLC1SEL0.5;
+  CLC1SEL0_LC1D2S0    : bit  absolute CLC1SEL0.4;
+  CLC1SEL0_LC1D1S2    : bit  absolute CLC1SEL0.3;
+  CLC1SEL0_LC1D1S1    : bit  absolute CLC1SEL0.2;
+  CLC1SEL0_LC1D1S0    : bit  absolute CLC1SEL0.1;
+  CLC1SEL1            : byte absolute $0033;
+  CLC1SEL1_LC1D4S2    : bit  absolute CLC1SEL1.6;
+  CLC1SEL1_LC1D4S1    : bit  absolute CLC1SEL1.5;
+  CLC1SEL1_LC1D4S0    : bit  absolute CLC1SEL1.4;
+  CLC1SEL1_LC1D3S2    : bit  absolute CLC1SEL1.3;
+  CLC1SEL1_LC1D3S1    : bit  absolute CLC1SEL1.2;
+  CLC1SEL1_LC1D3S0    : bit  absolute CLC1SEL1.1;
+  CLC1POL             : byte absolute $0034;
+  CLC1POL_LC1POL      : bit  absolute CLC1POL.7;
+  CLC1POL_LC1G4POL    : bit  absolute CLC1POL.6;
+  CLC1POL_LC1G3POL    : bit  absolute CLC1POL.5;
+  CLC1POL_LC1G2POL    : bit  absolute CLC1POL.4;
+  CLC1POL_LC1G1POL    : bit  absolute CLC1POL.3;
+  CLC1GLS0            : byte absolute $0035;
+  CLC1GLS0_LC1G1D4T   : bit  absolute CLC1GLS0.7;
+  CLC1GLS0_LC1G1D4N   : bit  absolute CLC1GLS0.6;
+  CLC1GLS0_LC1G1D3T   : bit  absolute CLC1GLS0.5;
+  CLC1GLS0_LC1G1D3N   : bit  absolute CLC1GLS0.4;
+  CLC1GLS0_LC1G1D2T   : bit  absolute CLC1GLS0.3;
+  CLC1GLS0_LC1G1D2N   : bit  absolute CLC1GLS0.2;
+  CLC1GLS0_LC1G1D1T   : bit  absolute CLC1GLS0.1;
+  CLC1GLS0_LC1G1D1N   : bit  absolute CLC1GLS0.0;
+  CLC1GLS1            : byte absolute $0036;
+  CLC1GLS1_LC1G2D4T   : bit  absolute CLC1GLS1.7;
+  CLC1GLS1_LC1G2D4N   : bit  absolute CLC1GLS1.6;
+  CLC1GLS1_LC1G2D3T   : bit  absolute CLC1GLS1.5;
+  CLC1GLS1_LC1G2D3N   : bit  absolute CLC1GLS1.4;
+  CLC1GLS1_LC1G2D2T   : bit  absolute CLC1GLS1.3;
+  CLC1GLS1_LC1G2D2N   : bit  absolute CLC1GLS1.2;
+  CLC1GLS1_LC1G2D1T   : bit  absolute CLC1GLS1.1;
+  CLC1GLS1_LC1G2D1N   : bit  absolute CLC1GLS1.0;
+  CLC1GLS2            : byte absolute $0037;
+  CLC1GLS2_LC1G3D4T   : bit  absolute CLC1GLS2.7;
+  CLC1GLS2_LC1G3D4N   : bit  absolute CLC1GLS2.6;
+  CLC1GLS2_LC1G3D3T   : bit  absolute CLC1GLS2.5;
+  CLC1GLS2_LC1G3D3N   : bit  absolute CLC1GLS2.4;
+  CLC1GLS2_LC1G3D2T   : bit  absolute CLC1GLS2.3;
+  CLC1GLS2_LC1G3D2N   : bit  absolute CLC1GLS2.2;
+  CLC1GLS2_LC1G3D1T   : bit  absolute CLC1GLS2.1;
+  CLC1GLS2_LC1G3D1N   : bit  absolute CLC1GLS2.0;
+  CLC1GLS3            : byte absolute $0038;
+  CLC1GLS3_LC1G4D4T   : bit  absolute CLC1GLS3.7;
+  CLC1GLS3_LC1G4D4N   : bit  absolute CLC1GLS3.6;
+  CLC1GLS3_LC1G4D3T   : bit  absolute CLC1GLS3.5;
+  CLC1GLS3_LC1G4D3N   : bit  absolute CLC1GLS3.4;
+  CLC1GLS3_LC1G4D2T   : bit  absolute CLC1GLS3.3;
+  CLC1GLS3_LC1G4D2N   : bit  absolute CLC1GLS3.2;
+  CLC1GLS3_LC1G4D1T   : bit  absolute CLC1GLS3.1;
+  CLC1GLS3_LC1G4D1N   : bit  absolute CLC1GLS3.0;
+  CWG1CON0            : byte absolute $0039;
+  CWG1CON0_G1EN       : bit  absolute CWG1CON0.6;
+  CWG1CON0_G1OEB      : bit  absolute CWG1CON0.5;
+  CWG1CON0_G1OEA      : bit  absolute CWG1CON0.4;
+  CWG1CON0_G1POLB     : bit  absolute CWG1CON0.3;
+  CWG1CON0_G1POLA     : bit  absolute CWG1CON0.2;
+  CWG1CON0_G1CS0      : bit  absolute CWG1CON0.1;
+  CWG1CON1            : byte absolute $003a;
+  CWG1CON1_G1ASDLB1   : bit  absolute CWG1CON1.7;
+  CWG1CON1_G1ASDLB0   : bit  absolute CWG1CON1.6;
+  CWG1CON1_G1ASDLA1   : bit  absolute CWG1CON1.5;
+  CWG1CON1_G1ASDLA0   : bit  absolute CWG1CON1.4;
+  CWG1CON1_G1IS1      : bit  absolute CWG1CON1.2;
+  CWG1CON1_G1IS0      : bit  absolute CWG1CON1.1;
+  CWG1CON2            : byte absolute $003b;
+  CWG1CON2_G1ASE      : bit  absolute CWG1CON2.4;
+  CWG1CON2_G1ARSEN    : bit  absolute CWG1CON2.3;
+  CWG1CON2_G1ASDSCLC1 : bit  absolute CWG1CON2.2;
+  CWG1CON2_G1ASDSFLT  : bit  absolute CWG1CON2.1;
+  CWG1DBR             : byte absolute $003c;
+  CWG1DBR_CWG1DBR5    : bit  absolute CWG1DBR.5;
+  CWG1DBR_CWG1DBR4    : bit  absolute CWG1DBR.4;
+  CWG1DBR_CWG1DBR3    : bit  absolute CWG1DBR.3;
+  CWG1DBR_CWG1DBR2    : bit  absolute CWG1DBR.2;
+  CWG1DBR_CWG1DBR1    : bit  absolute CWG1DBR.1;
+  CWG1DBR_CWG1DBR0    : bit  absolute CWG1DBR.0;
+  CWG1DBF             : byte absolute $003d;
+  CWG1DBF_CWG1DBF5    : bit  absolute CWG1DBF.5;
+  CWG1DBF_CWG1DBF4    : bit  absolute CWG1DBF.4;
+  CWG1DBF_CWG1DBF3    : bit  absolute CWG1DBF.3;
+  CWG1DBF_CWG1DBF2    : bit  absolute CWG1DBF.2;
+  CWG1DBF_CWG1DBF1    : bit  absolute CWG1DBF.1;
+  CWG1DBF_CWG1DBF0    : bit  absolute CWG1DBF.0;
+  VREGCON             : byte absolute $003e;
+  VREGCON_VREGPM1     : bit  absolute VREGCON.1;
+  VREGCON_VREGPM0     : bit  absolute VREGCON.0;
+  BORCON              : byte absolute $003f;
+  BORCON_SBOREN       : bit  absolute BORCON.7;
+  BORCON_BORFS        : bit  absolute BORCON.6;
+  BORCON_BORRDY       : bit  absolute BORCON.5;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-02E:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, TRISA, LATA, ANSELA, WPUA, PCLATH, INTCON, PIR1, PIE1, OPTION_REG, PCON, OSCCON, TMR2, PR2, T2CON, PWM1DCL, PWM1DCH, PWM1CON, PWM2DCL, PWM2DCH, PWM2CON, IOCAP, IOCAN, IOCAF, FVRCON, ADRES, ADCON, PMADRL, PMADRH, PMDATL, PMDATH, PMCON1, PMCON2, CLKRCON, NCO1ACCL, NCO1ACCH, NCO1ACCU, NCO1INCL, NCO1INCH, NCO1INCU, NCO1CON, NCO1CLK
+  {$SET_STATE_RAM '030-03F:SFR'}  // WDTCON, CLC1CON, CLC1SEL0, CLC1SEL1, CLC1POL, CLC1GLS0, CLC1GLS1, CLC1GLS2, CLC1GLS3, CWG1CON0, CWG1CON1, CWG1CON2, CWG1DBR, CWG1DBF, VREGCON, BORCON
+  {$SET_STATE_RAM '040-07F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:0F'} // PORTA
+  {$SET_UNIMP_BITS '006:07'} // TRISA
+  {$SET_UNIMP_BITS '007:07'} // LATA
+  {$SET_UNIMP_BITS '008:07'} // ANSELA
+  {$SET_UNIMP_BITS '009:0F'} // WPUA
+  {$SET_UNIMP_BITS '00A:01'} // PCLATH
+  {$SET_UNIMP_BITS '00C:5A'} // PIR1
+  {$SET_UNIMP_BITS '00D:5A'} // PIE1
+  {$SET_UNIMP_BITS '00F:03'} // PCON
+  {$SET_UNIMP_BITS '010:7B'} // OSCCON
+  {$SET_UNIMP_BITS '013:7F'} // T2CON
+  {$SET_UNIMP_BITS '014:C0'} // PWM1DCL
+  {$SET_UNIMP_BITS '016:F0'} // PWM1CON
+  {$SET_UNIMP_BITS '017:C0'} // PWM2DCL
+  {$SET_UNIMP_BITS '019:F0'} // PWM2CON
+  {$SET_UNIMP_BITS '01A:0F'} // IOCAP
+  {$SET_UNIMP_BITS '01B:0F'} // IOCAN
+  {$SET_UNIMP_BITS '01C:0F'} // IOCAF
+  {$SET_UNIMP_BITS '01D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '021:01'} // PMADRH
+  {$SET_UNIMP_BITS '023:3F'} // PMDATH
+  {$SET_UNIMP_BITS '024:7F'} // PMCON1
+  {$SET_UNIMP_BITS '026:40'} // CLKRCON
+  {$SET_UNIMP_BITS '029:0F'} // NCO1ACCU
+  {$SET_UNIMP_BITS '02C:00'} // NCO1INCU
+  {$SET_UNIMP_BITS '02D:F1'} // NCO1CON
+  {$SET_UNIMP_BITS '02E:E3'} // NCO1CLK
+  {$SET_UNIMP_BITS '030:3F'} // WDTCON
+  {$SET_UNIMP_BITS '032:77'} // CLC1SEL0
+  {$SET_UNIMP_BITS '033:77'} // CLC1SEL1
+  {$SET_UNIMP_BITS '034:8F'} // CLC1POL
+  {$SET_UNIMP_BITS '039:F9'} // CWG1CON0
+  {$SET_UNIMP_BITS '03A:F3'} // CWG1CON1
+  {$SET_UNIMP_BITS '03B:C3'} // CWG1CON2
+  {$SET_UNIMP_BITS '03C:3F'} // CWG1DBR
+  {$SET_UNIMP_BITS '03D:3F'} // CWG1DBF
+  {$SET_UNIMP_BITS '03E:03'} // VREGCON
+  {$SET_UNIMP_BITS '03F:C1'} // BORCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA0/PWM1/CLC1IN1/CWG1A/AN0/ICSPDAT
+  // Pin  2 : RA1/PWM2/CLC1/CWG1B/AN1/CLKIN/ICSPCLK/NCO1CLK
+  // Pin  3 : RA2/INT/T0CKI/NCO1/CLC1IN2/CLKR/AN2/CWG1FLT
+  // Pin  4 : RA3/MCLR/VPP
+  // Pin  5 : VDD
+  // Pin  6 : VSS
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:1-1,2-2,3-3,4-4'} // PORTA
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode
+  {$define _DEBUG_OFF    = $1FFF}  // In-Circuit Debugger disabled, ICSPCLK and ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON     = $1FFE}  // In-Circuit Debugger enabled, ICSPCLK and ICSPDAT are dedicated to the debugger
+
+  // WRT : Flash Memory Self-Write Protection
+  {$define _WRT_OFF      = $1FFF}  // Write protection off
+  {$define _WRT_BOOT     = $1FFD}  // 000h to 03Fh write protected, 040h to 0FFh may be modified by PMCON control
+  {$define _WRT_HALF     = $1FFB}  // 000h to 07Fh write protected, 080h to 0FFh may be modified by PMCON control
+  {$define _WRT_ALL      = $1FF9}  // 000h to 0FFh write protected, no addresses may be modified by PMCON control
+
+  // BORV : Brown-out Reset Voltage Selection
+  {$define _BORV_LO      = $1FFF}  // Brown-out Reset Voltage (Vbor), low trip point selected.
+  {$define _BORV_HI      = $1FF7}  // Brown-out Reset Voltage (Vbor), high trip point selected.
+
+  // LPBOR : Brown-out Reset Selection bits
+  {$define _LPBOR_ON     = $1FFF}  // BOR enabled
+  {$define _LPBOR_OFF    = $1FEF}  // BOR disabled
+
+  // LVP : Low-Voltage Programming Enable
+  {$define _LVP_ON       = $1FFF}  // Low-voltage programming enabled
+  {$define _LVP_OFF      = $1FDF}  // High-voltage on MCLR/VPP must be used for programming
+
+  // CP : Code Protection bit
+  {$define _CP_OFF       = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON        = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON     = $1FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF    = $1F7F}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF    = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON     = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable
+  {$define _WDTE_ON      = $1FFF}  // WDT enabled
+  {$define _WDTE_NSLEEP  = $1DFF}  // WDT enabled while running and disabled in Sleep
+  {$define _WDTE_SWDTEN  = $1BFF}  // WDT controlled by the SWDTEN bit in the WDTCON register
+  {$define _WDTE_OFF     = $19FF}  // WDT disabled
+
+  // BOREN : Brown-out Reset Enable
+  {$define _BOREN_ON     = $1FFF}  // Brown-out Reset enabled
+  {$define _BOREN_NSLEEP = $17FF}  // Brown-out Reset enabled while running and disabled in Sleep
+  {$define _BOREN_SBODEN = $0FFF}  // Brown-out Reset controlled by the SBOREN bit in the BORCON register
+  {$define _BOREN_OFF    = $07FF}  // Brown-out Reset disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_INTOSC  = $1FFF}  // INTOSC oscillator: CLKIN function disabled
+  {$define _FOSC_EC      = $3FFF}  // EC: CLKIN function enabled
+
+implementation
+end.

--- a/PIC10F322.pas
+++ b/PIC10F322.pas
@@ -1,0 +1,465 @@
+unit PIC10F322;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F322'}
+{$SET PIC_MAXFREQ  = 16000000}
+{$SET PIC_NPINS    = 6}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF                : byte absolute $0000;
+  TMR0                : byte absolute $0001;
+  PCL                 : byte absolute $0002;
+  STATUS              : byte absolute $0003;
+  STATUS_IRP          : bit  absolute STATUS.7;
+  STATUS_RP1          : bit  absolute STATUS.6;
+  STATUS_RP0          : bit  absolute STATUS.5;
+  STATUS_TO           : bit  absolute STATUS.4;
+  STATUS_PD           : bit  absolute STATUS.3;
+  STATUS_Z            : bit  absolute STATUS.2;
+  STATUS_DC           : bit  absolute STATUS.1;
+  STATUS_C            : bit  absolute STATUS.0;
+  FSR                 : byte absolute $0004;
+  PORTA               : byte absolute $0005;
+  PORTA_RA3           : bit  absolute PORTA.4;
+  PORTA_RA2           : bit  absolute PORTA.3;
+  PORTA_RA1           : bit  absolute PORTA.2;
+  PORTA_RA0           : bit  absolute PORTA.1;
+  TRISA               : byte absolute $0006;
+  TRISA_TRISA2        : bit  absolute TRISA.3;
+  TRISA_TRISA1        : bit  absolute TRISA.2;
+  TRISA_TRISA0        : bit  absolute TRISA.1;
+  LATA                : byte absolute $0007;
+  LATA_LATA2          : bit  absolute LATA.2;
+  LATA_LATA1          : bit  absolute LATA.1;
+  LATA_LATA0          : bit  absolute LATA.0;
+  ANSELA              : byte absolute $0008;
+  ANSELA_ANSA2        : bit  absolute ANSELA.2;
+  ANSELA_ANSA1        : bit  absolute ANSELA.1;
+  ANSELA_ANSA0        : bit  absolute ANSELA.0;
+  WPUA                : byte absolute $0009;
+  WPUA_WPUA3          : bit  absolute WPUA.3;
+  WPUA_WPUA2          : bit  absolute WPUA.2;
+  WPUA_WPUA1          : bit  absolute WPUA.1;
+  WPUA_WPUA0          : bit  absolute WPUA.0;
+  PCLATH              : byte absolute $000a;
+  PCLATH_PCLH0        : bit  absolute PCLATH.4;
+  INTCON              : byte absolute $000b;
+  INTCON_GIE          : bit  absolute INTCON.7;
+  INTCON_PEIE         : bit  absolute INTCON.6;
+  INTCON_TMR0IE       : bit  absolute INTCON.5;
+  INTCON_INTE         : bit  absolute INTCON.4;
+  INTCON_IOCIE        : bit  absolute INTCON.3;
+  INTCON_TMR0IF       : bit  absolute INTCON.2;
+  INTCON_INTF         : bit  absolute INTCON.1;
+  INTCON_IOCIF        : bit  absolute INTCON.0;
+  PIR1                : byte absolute $000c;
+  PIR1_ADIF           : bit  absolute PIR1.4;
+  PIR1_NCO1IF         : bit  absolute PIR1.3;
+  PIR1_CLC1IF         : bit  absolute PIR1.2;
+  PIR1_TMR2IF         : bit  absolute PIR1.1;
+  PIE1                : byte absolute $000d;
+  PIE1_ADIE           : bit  absolute PIE1.4;
+  PIE1_NCO1IE         : bit  absolute PIE1.3;
+  PIE1_CLC1IE         : bit  absolute PIE1.2;
+  PIE1_TMR2IE         : bit  absolute PIE1.1;
+  OPTION_REG          : byte absolute $000e;
+  OPTION_REG_WPUEN    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG   : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS     : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE     : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA      : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2      : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1      : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0      : bit  absolute OPTION_REG.0;
+  PCON                : byte absolute $000f;
+  PCON_POR            : bit  absolute PCON.1;
+  PCON_BOR            : bit  absolute PCON.0;
+  OSCCON              : byte absolute $0010;
+  OSCCON_IRCF2        : bit  absolute OSCCON.6;
+  OSCCON_IRCF1        : bit  absolute OSCCON.5;
+  OSCCON_IRCF0        : bit  absolute OSCCON.4;
+  OSCCON_HFIOFR       : bit  absolute OSCCON.3;
+  OSCCON_LFIOFR       : bit  absolute OSCCON.2;
+  OSCCON_HFIOFS       : bit  absolute OSCCON.1;
+  TMR2                : byte absolute $0011;
+  PR2                 : byte absolute $0012;
+  T2CON               : byte absolute $0013;
+  T2CON_TOUTPS3       : bit  absolute T2CON.6;
+  T2CON_TOUTPS2       : bit  absolute T2CON.5;
+  T2CON_TOUTPS1       : bit  absolute T2CON.4;
+  T2CON_TOUTPS0       : bit  absolute T2CON.3;
+  T2CON_TMR2ON        : bit  absolute T2CON.2;
+  T2CON_T2CKPS0       : bit  absolute T2CON.1;
+  PWM1DCL             : byte absolute $0014;
+  PWM1DCL_PWM1DCL1    : bit  absolute PWM1DCL.2;
+  PWM1DCL_PWM1DCL0    : bit  absolute PWM1DCL.1;
+  PWM1DCH             : byte absolute $0015;
+  PWM1DCH_PWM1DCH7    : bit  absolute PWM1DCH.7;
+  PWM1DCH_PWM1DCH6    : bit  absolute PWM1DCH.6;
+  PWM1DCH_PWM1DCH5    : bit  absolute PWM1DCH.5;
+  PWM1DCH_PWM1DCH4    : bit  absolute PWM1DCH.4;
+  PWM1DCH_PWM1DCH3    : bit  absolute PWM1DCH.3;
+  PWM1DCH_PWM1DCH2    : bit  absolute PWM1DCH.2;
+  PWM1DCH_PWM1DCH1    : bit  absolute PWM1DCH.1;
+  PWM1DCH_PWM1DCH0    : bit  absolute PWM1DCH.0;
+  PWM1CON             : byte absolute $0016;
+  PWM1CON_PWM1EN      : bit  absolute PWM1CON.4;
+  PWM1CON_PWM1OE      : bit  absolute PWM1CON.3;
+  PWM1CON_PWM1OUT     : bit  absolute PWM1CON.2;
+  PWM1CON_PWM1POL     : bit  absolute PWM1CON.1;
+  PWM2DCL             : byte absolute $0017;
+  PWM2DCL_PWM2DCL1    : bit  absolute PWM2DCL.2;
+  PWM2DCL_PWM2DCL0    : bit  absolute PWM2DCL.1;
+  PWM2DCH             : byte absolute $0018;
+  PWM2DCH_PWM2DCH7    : bit  absolute PWM2DCH.7;
+  PWM2DCH_PWM2DCH6    : bit  absolute PWM2DCH.6;
+  PWM2DCH_PWM2DCH5    : bit  absolute PWM2DCH.5;
+  PWM2DCH_PWM2DCH4    : bit  absolute PWM2DCH.4;
+  PWM2DCH_PWM2DCH3    : bit  absolute PWM2DCH.3;
+  PWM2DCH_PWM2DCH2    : bit  absolute PWM2DCH.2;
+  PWM2DCH_PWM2DCH1    : bit  absolute PWM2DCH.1;
+  PWM2DCH_PWM2DCH0    : bit  absolute PWM2DCH.0;
+  PWM2CON             : byte absolute $0019;
+  PWM2CON_PWM2EN      : bit  absolute PWM2CON.4;
+  PWM2CON_PWM2OE      : bit  absolute PWM2CON.3;
+  PWM2CON_PWM2OUT     : bit  absolute PWM2CON.2;
+  PWM2CON_PWM2POL     : bit  absolute PWM2CON.1;
+  IOCAP               : byte absolute $001a;
+  IOCAP_IOCAP3        : bit  absolute IOCAP.6;
+  IOCAP_IOCAP2        : bit  absolute IOCAP.5;
+  IOCAP_IOCAP1        : bit  absolute IOCAP.4;
+  IOCAP_IOCAP0        : bit  absolute IOCAP.3;
+  IOCAN               : byte absolute $001b;
+  IOCAN_IOCAN3        : bit  absolute IOCAN.4;
+  IOCAN_IOCAN2        : bit  absolute IOCAN.3;
+  IOCAN_IOCAN1        : bit  absolute IOCAN.2;
+  IOCAN_IOCAN0        : bit  absolute IOCAN.1;
+  IOCAF               : byte absolute $001c;
+  IOCAF_IOCAF3        : bit  absolute IOCAF.4;
+  IOCAF_IOCAF2        : bit  absolute IOCAF.3;
+  IOCAF_IOCAF1        : bit  absolute IOCAF.2;
+  IOCAF_IOCAF0        : bit  absolute IOCAF.1;
+  FVRCON              : byte absolute $001d;
+  FVRCON_FVREN        : bit  absolute FVRCON.6;
+  FVRCON_FVRRDY       : bit  absolute FVRCON.5;
+  FVRCON_TSEN         : bit  absolute FVRCON.4;
+  FVRCON_TSRNG        : bit  absolute FVRCON.3;
+  FVRCON_ADFVR1       : bit  absolute FVRCON.1;
+  FVRCON_ADFVR0       : bit  absolute FVRCON.0;
+  ADRES               : byte absolute $001e;
+  ADCON               : byte absolute $001f;
+  ADCON_ADCS2         : bit  absolute ADCON.7;
+  ADCON_ADCS1         : bit  absolute ADCON.6;
+  ADCON_ADCS0         : bit  absolute ADCON.5;
+  ADCON_CHS2          : bit  absolute ADCON.4;
+  ADCON_CHS1          : bit  absolute ADCON.3;
+  ADCON_CHS0          : bit  absolute ADCON.2;
+  ADCON_GO_nDONE      : bit  absolute ADCON.1;
+  ADCON_ADON          : bit  absolute ADCON.0;
+  PMADRL              : byte absolute $0020;
+  PMADRH              : byte absolute $0021;
+  PMADRH_PMADR8       : bit  absolute PMADRH.3;
+  PMDATL              : byte absolute $0022;
+  PMDATH              : byte absolute $0023;
+  PMCON1              : byte absolute $0024;
+  PMCON1_CFGS         : bit  absolute PMCON1.6;
+  PMCON1_LWLO         : bit  absolute PMCON1.5;
+  PMCON1_FREE         : bit  absolute PMCON1.4;
+  PMCON1_WRERR        : bit  absolute PMCON1.3;
+  PMCON1_WREN         : bit  absolute PMCON1.2;
+  PMCON1_WR           : bit  absolute PMCON1.1;
+  PMCON1_RD           : bit  absolute PMCON1.0;
+  PMCON2              : byte absolute $0025;
+  CLKRCON             : byte absolute $0026;
+  CLKRCON_CLKROE      : bit  absolute CLKRCON.6;
+  NCO1ACCL            : byte absolute $0027;
+  NCO1ACCL_NCO1ACC7   : bit  absolute NCO1ACCL.7;
+  NCO1ACCL_NCO1ACC6   : bit  absolute NCO1ACCL.6;
+  NCO1ACCL_NCO1ACC5   : bit  absolute NCO1ACCL.5;
+  NCO1ACCL_NCO1ACC4   : bit  absolute NCO1ACCL.4;
+  NCO1ACCL_NCO1ACC3   : bit  absolute NCO1ACCL.3;
+  NCO1ACCL_NCO1ACC2   : bit  absolute NCO1ACCL.2;
+  NCO1ACCL_NCO1ACC1   : bit  absolute NCO1ACCL.1;
+  NCO1ACCL_NCO1ACC0   : bit  absolute NCO1ACCL.0;
+  NCO1ACCH            : byte absolute $0028;
+  NCO1ACCH_NCO1ACC15  : bit  absolute NCO1ACCH.7;
+  NCO1ACCH_NCO1ACC14  : bit  absolute NCO1ACCH.6;
+  NCO1ACCH_NCO1ACC13  : bit  absolute NCO1ACCH.5;
+  NCO1ACCH_NCO1ACC12  : bit  absolute NCO1ACCH.4;
+  NCO1ACCH_NCO1ACC11  : bit  absolute NCO1ACCH.3;
+  NCO1ACCH_NCO1ACC10  : bit  absolute NCO1ACCH.2;
+  NCO1ACCH_NCO1ACC9   : bit  absolute NCO1ACCH.1;
+  NCO1ACCH_NCO1ACC8   : bit  absolute NCO1ACCH.0;
+  NCO1ACCU            : byte absolute $0029;
+  NCO1ACCU_NCO1ACC19  : bit  absolute NCO1ACCU.4;
+  NCO1ACCU_NCO1ACC18  : bit  absolute NCO1ACCU.3;
+  NCO1ACCU_NCO1ACC17  : bit  absolute NCO1ACCU.2;
+  NCO1ACCU_NCO1ACC16  : bit  absolute NCO1ACCU.1;
+  NCO1INCL            : byte absolute $002a;
+  NCO1INCL_NCO1INC7   : bit  absolute NCO1INCL.7;
+  NCO1INCL_NCO1INC6   : bit  absolute NCO1INCL.6;
+  NCO1INCL_NCO1INC5   : bit  absolute NCO1INCL.5;
+  NCO1INCL_NCO1INC4   : bit  absolute NCO1INCL.4;
+  NCO1INCL_NCO1INC3   : bit  absolute NCO1INCL.3;
+  NCO1INCL_NCO1INC2   : bit  absolute NCO1INCL.2;
+  NCO1INCL_NCO1INC1   : bit  absolute NCO1INCL.1;
+  NCO1INCL_NCO1INC0   : bit  absolute NCO1INCL.0;
+  NCO1INCH            : byte absolute $002b;
+  NCO1INCH_NCO1INC15  : bit  absolute NCO1INCH.7;
+  NCO1INCH_NCO1INC14  : bit  absolute NCO1INCH.6;
+  NCO1INCH_NCO1INC13  : bit  absolute NCO1INCH.5;
+  NCO1INCH_NCO1INC12  : bit  absolute NCO1INCH.4;
+  NCO1INCH_NCO1INC11  : bit  absolute NCO1INCH.3;
+  NCO1INCH_NCO1INC10  : bit  absolute NCO1INCH.2;
+  NCO1INCH_NCO1INC9   : bit  absolute NCO1INCH.1;
+  NCO1INCH_NCO1INC8   : bit  absolute NCO1INCH.0;
+  NCO1INCU            : byte absolute $002c;
+  NCO1CON             : byte absolute $002d;
+  NCO1CON_N1EN        : bit  absolute NCO1CON.5;
+  NCO1CON_N1OE        : bit  absolute NCO1CON.4;
+  NCO1CON_N1OUT       : bit  absolute NCO1CON.3;
+  NCO1CON_N1POL       : bit  absolute NCO1CON.2;
+  NCO1CON_N1PFM       : bit  absolute NCO1CON.1;
+  NCO1CLK             : byte absolute $002e;
+  NCO1CLK_N1PWS2      : bit  absolute NCO1CLK.5;
+  NCO1CLK_N1PWS1      : bit  absolute NCO1CLK.4;
+  NCO1CLK_N1PWS0      : bit  absolute NCO1CLK.3;
+  NCO1CLK_N1CKS1      : bit  absolute NCO1CLK.2;
+  NCO1CLK_N1CKS0      : bit  absolute NCO1CLK.1;
+  WDTCON              : byte absolute $0030;
+  WDTCON_WDTPS4       : bit  absolute WDTCON.5;
+  WDTCON_WDTPS3       : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2       : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1       : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0       : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN       : bit  absolute WDTCON.0;
+  CLC1CON             : byte absolute $0031;
+  CLC1CON_LC1EN       : bit  absolute CLC1CON.7;
+  CLC1CON_LC1OE       : bit  absolute CLC1CON.6;
+  CLC1CON_LC1OUT      : bit  absolute CLC1CON.5;
+  CLC1CON_LC1INTP     : bit  absolute CLC1CON.4;
+  CLC1CON_LC1INTN     : bit  absolute CLC1CON.3;
+  CLC1CON_LC1MODE2    : bit  absolute CLC1CON.2;
+  CLC1CON_LC1MODE1    : bit  absolute CLC1CON.1;
+  CLC1CON_LC1MODE0    : bit  absolute CLC1CON.0;
+  CLC1SEL0            : byte absolute $0032;
+  CLC1SEL0_LC1D2S2    : bit  absolute CLC1SEL0.6;
+  CLC1SEL0_LC1D2S1    : bit  absolute CLC1SEL0.5;
+  CLC1SEL0_LC1D2S0    : bit  absolute CLC1SEL0.4;
+  CLC1SEL0_LC1D1S2    : bit  absolute CLC1SEL0.3;
+  CLC1SEL0_LC1D1S1    : bit  absolute CLC1SEL0.2;
+  CLC1SEL0_LC1D1S0    : bit  absolute CLC1SEL0.1;
+  CLC1SEL1            : byte absolute $0033;
+  CLC1SEL1_LC1D4S2    : bit  absolute CLC1SEL1.6;
+  CLC1SEL1_LC1D4S1    : bit  absolute CLC1SEL1.5;
+  CLC1SEL1_LC1D4S0    : bit  absolute CLC1SEL1.4;
+  CLC1SEL1_LC1D3S2    : bit  absolute CLC1SEL1.3;
+  CLC1SEL1_LC1D3S1    : bit  absolute CLC1SEL1.2;
+  CLC1SEL1_LC1D3S0    : bit  absolute CLC1SEL1.1;
+  CLC1POL             : byte absolute $0034;
+  CLC1POL_LC1POL      : bit  absolute CLC1POL.7;
+  CLC1POL_LC1G4POL    : bit  absolute CLC1POL.6;
+  CLC1POL_LC1G3POL    : bit  absolute CLC1POL.5;
+  CLC1POL_LC1G2POL    : bit  absolute CLC1POL.4;
+  CLC1POL_LC1G1POL    : bit  absolute CLC1POL.3;
+  CLC1GLS0            : byte absolute $0035;
+  CLC1GLS0_LC1G1D4T   : bit  absolute CLC1GLS0.7;
+  CLC1GLS0_LC1G1D4N   : bit  absolute CLC1GLS0.6;
+  CLC1GLS0_LC1G1D3T   : bit  absolute CLC1GLS0.5;
+  CLC1GLS0_LC1G1D3N   : bit  absolute CLC1GLS0.4;
+  CLC1GLS0_LC1G1D2T   : bit  absolute CLC1GLS0.3;
+  CLC1GLS0_LC1G1D2N   : bit  absolute CLC1GLS0.2;
+  CLC1GLS0_LC1G1D1T   : bit  absolute CLC1GLS0.1;
+  CLC1GLS0_LC1G1D1N   : bit  absolute CLC1GLS0.0;
+  CLC1GLS1            : byte absolute $0036;
+  CLC1GLS1_LC1G2D4T   : bit  absolute CLC1GLS1.7;
+  CLC1GLS1_LC1G2D4N   : bit  absolute CLC1GLS1.6;
+  CLC1GLS1_LC1G2D3T   : bit  absolute CLC1GLS1.5;
+  CLC1GLS1_LC1G2D3N   : bit  absolute CLC1GLS1.4;
+  CLC1GLS1_LC1G2D2T   : bit  absolute CLC1GLS1.3;
+  CLC1GLS1_LC1G2D2N   : bit  absolute CLC1GLS1.2;
+  CLC1GLS1_LC1G2D1T   : bit  absolute CLC1GLS1.1;
+  CLC1GLS1_LC1G2D1N   : bit  absolute CLC1GLS1.0;
+  CLC1GLS2            : byte absolute $0037;
+  CLC1GLS2_LC1G3D4T   : bit  absolute CLC1GLS2.7;
+  CLC1GLS2_LC1G3D4N   : bit  absolute CLC1GLS2.6;
+  CLC1GLS2_LC1G3D3T   : bit  absolute CLC1GLS2.5;
+  CLC1GLS2_LC1G3D3N   : bit  absolute CLC1GLS2.4;
+  CLC1GLS2_LC1G3D2T   : bit  absolute CLC1GLS2.3;
+  CLC1GLS2_LC1G3D2N   : bit  absolute CLC1GLS2.2;
+  CLC1GLS2_LC1G3D1T   : bit  absolute CLC1GLS2.1;
+  CLC1GLS2_LC1G3D1N   : bit  absolute CLC1GLS2.0;
+  CLC1GLS3            : byte absolute $0038;
+  CLC1GLS3_LC1G4D4T   : bit  absolute CLC1GLS3.7;
+  CLC1GLS3_LC1G4D4N   : bit  absolute CLC1GLS3.6;
+  CLC1GLS3_LC1G4D3T   : bit  absolute CLC1GLS3.5;
+  CLC1GLS3_LC1G4D3N   : bit  absolute CLC1GLS3.4;
+  CLC1GLS3_LC1G4D2T   : bit  absolute CLC1GLS3.3;
+  CLC1GLS3_LC1G4D2N   : bit  absolute CLC1GLS3.2;
+  CLC1GLS3_LC1G4D1T   : bit  absolute CLC1GLS3.1;
+  CLC1GLS3_LC1G4D1N   : bit  absolute CLC1GLS3.0;
+  CWG1CON0            : byte absolute $0039;
+  CWG1CON0_G1EN       : bit  absolute CWG1CON0.6;
+  CWG1CON0_G1OEB      : bit  absolute CWG1CON0.5;
+  CWG1CON0_G1OEA      : bit  absolute CWG1CON0.4;
+  CWG1CON0_G1POLB     : bit  absolute CWG1CON0.3;
+  CWG1CON0_G1POLA     : bit  absolute CWG1CON0.2;
+  CWG1CON0_G1CS0      : bit  absolute CWG1CON0.1;
+  CWG1CON1            : byte absolute $003a;
+  CWG1CON1_G1ASDLB1   : bit  absolute CWG1CON1.7;
+  CWG1CON1_G1ASDLB0   : bit  absolute CWG1CON1.6;
+  CWG1CON1_G1ASDLA1   : bit  absolute CWG1CON1.5;
+  CWG1CON1_G1ASDLA0   : bit  absolute CWG1CON1.4;
+  CWG1CON1_G1IS1      : bit  absolute CWG1CON1.2;
+  CWG1CON1_G1IS0      : bit  absolute CWG1CON1.1;
+  CWG1CON2            : byte absolute $003b;
+  CWG1CON2_G1ASE      : bit  absolute CWG1CON2.4;
+  CWG1CON2_G1ARSEN    : bit  absolute CWG1CON2.3;
+  CWG1CON2_G1ASDSCLC1 : bit  absolute CWG1CON2.2;
+  CWG1CON2_G1ASDSFLT  : bit  absolute CWG1CON2.1;
+  CWG1DBR             : byte absolute $003c;
+  CWG1DBR_CWG1DBR5    : bit  absolute CWG1DBR.5;
+  CWG1DBR_CWG1DBR4    : bit  absolute CWG1DBR.4;
+  CWG1DBR_CWG1DBR3    : bit  absolute CWG1DBR.3;
+  CWG1DBR_CWG1DBR2    : bit  absolute CWG1DBR.2;
+  CWG1DBR_CWG1DBR1    : bit  absolute CWG1DBR.1;
+  CWG1DBR_CWG1DBR0    : bit  absolute CWG1DBR.0;
+  CWG1DBF             : byte absolute $003d;
+  CWG1DBF_CWG1DBF5    : bit  absolute CWG1DBF.5;
+  CWG1DBF_CWG1DBF4    : bit  absolute CWG1DBF.4;
+  CWG1DBF_CWG1DBF3    : bit  absolute CWG1DBF.3;
+  CWG1DBF_CWG1DBF2    : bit  absolute CWG1DBF.2;
+  CWG1DBF_CWG1DBF1    : bit  absolute CWG1DBF.1;
+  CWG1DBF_CWG1DBF0    : bit  absolute CWG1DBF.0;
+  VREGCON             : byte absolute $003e;
+  VREGCON_VREGPM1     : bit  absolute VREGCON.1;
+  VREGCON_VREGPM0     : bit  absolute VREGCON.0;
+  BORCON              : byte absolute $003f;
+  BORCON_SBOREN       : bit  absolute BORCON.7;
+  BORCON_BORFS        : bit  absolute BORCON.6;
+  BORCON_BORRDY       : bit  absolute BORCON.5;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-02E:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, TRISA, LATA, ANSELA, WPUA, PCLATH, INTCON, PIR1, PIE1, OPTION_REG, PCON, OSCCON, TMR2, PR2, T2CON, PWM1DCL, PWM1DCH, PWM1CON, PWM2DCL, PWM2DCH, PWM2CON, IOCAP, IOCAN, IOCAF, FVRCON, ADRES, ADCON, PMADRL, PMADRH, PMDATL, PMDATH, PMCON1, PMCON2, CLKRCON, NCO1ACCL, NCO1ACCH, NCO1ACCU, NCO1INCL, NCO1INCH, NCO1INCU, NCO1CON, NCO1CLK
+  {$SET_STATE_RAM '030-03F:SFR'}  // WDTCON, CLC1CON, CLC1SEL0, CLC1SEL1, CLC1POL, CLC1GLS0, CLC1GLS1, CLC1GLS2, CLC1GLS3, CWG1CON0, CWG1CON1, CWG1CON2, CWG1DBR, CWG1DBF, VREGCON, BORCON
+  {$SET_STATE_RAM '040-07F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:0F'} // PORTA
+  {$SET_UNIMP_BITS '006:07'} // TRISA
+  {$SET_UNIMP_BITS '007:07'} // LATA
+  {$SET_UNIMP_BITS '008:07'} // ANSELA
+  {$SET_UNIMP_BITS '009:0F'} // WPUA
+  {$SET_UNIMP_BITS '00A:01'} // PCLATH
+  {$SET_UNIMP_BITS '00C:5A'} // PIR1
+  {$SET_UNIMP_BITS '00D:5A'} // PIE1
+  {$SET_UNIMP_BITS '00F:03'} // PCON
+  {$SET_UNIMP_BITS '010:7B'} // OSCCON
+  {$SET_UNIMP_BITS '013:7F'} // T2CON
+  {$SET_UNIMP_BITS '014:C0'} // PWM1DCL
+  {$SET_UNIMP_BITS '016:F0'} // PWM1CON
+  {$SET_UNIMP_BITS '017:C0'} // PWM2DCL
+  {$SET_UNIMP_BITS '019:F0'} // PWM2CON
+  {$SET_UNIMP_BITS '01A:0F'} // IOCAP
+  {$SET_UNIMP_BITS '01B:0F'} // IOCAN
+  {$SET_UNIMP_BITS '01C:0F'} // IOCAF
+  {$SET_UNIMP_BITS '01D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '021:01'} // PMADRH
+  {$SET_UNIMP_BITS '023:3F'} // PMDATH
+  {$SET_UNIMP_BITS '024:7F'} // PMCON1
+  {$SET_UNIMP_BITS '026:40'} // CLKRCON
+  {$SET_UNIMP_BITS '029:0F'} // NCO1ACCU
+  {$SET_UNIMP_BITS '02C:00'} // NCO1INCU
+  {$SET_UNIMP_BITS '02D:F1'} // NCO1CON
+  {$SET_UNIMP_BITS '02E:E3'} // NCO1CLK
+  {$SET_UNIMP_BITS '030:3F'} // WDTCON
+  {$SET_UNIMP_BITS '032:77'} // CLC1SEL0
+  {$SET_UNIMP_BITS '033:77'} // CLC1SEL1
+  {$SET_UNIMP_BITS '034:8F'} // CLC1POL
+  {$SET_UNIMP_BITS '039:F9'} // CWG1CON0
+  {$SET_UNIMP_BITS '03A:F3'} // CWG1CON1
+  {$SET_UNIMP_BITS '03B:C3'} // CWG1CON2
+  {$SET_UNIMP_BITS '03C:3F'} // CWG1DBR
+  {$SET_UNIMP_BITS '03D:3F'} // CWG1DBF
+  {$SET_UNIMP_BITS '03E:03'} // VREGCON
+  {$SET_UNIMP_BITS '03F:C1'} // BORCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA0/PWM1/CLC1IN1/CWG1A/AN0/ICSPDAT
+  // Pin  2 : RA1/PWM2/CLC1/CWG1B/AN1/CLKIN/ICSPCLK/NCO1CLK
+  // Pin  3 : RA2/INT/T0CKI/NCO1/CLC1IN2/CLKR/AN2/CWG1FLT
+  // Pin  4 : RA3/MCLR/VPP
+  // Pin  5 : VDD
+  // Pin  6 : VSS
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:1-1,2-2,3-3,4-4'} // PORTA
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode
+  {$define _DEBUG_OFF    = $1FFF}  // In-Circuit Debugger disabled, ICSPCLK and ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON     = $1FFE}  // In-Circuit Debugger enabled, ICSPCLK and ICSPDAT are dedicated to the debugger
+
+  // WRT : Flash Memory Self-Write Protection
+  {$define _WRT_OFF      = $1FFF}  // Write protection off
+  {$define _WRT_BOOT     = $1FFD}  // 000h to 07Fh write protected, 080h to 1FFh may be modified by PMCON control
+  {$define _WRT_HALF     = $1FFB}  // 000h to 0FFh write protected, 100h to 1FFh may be modified by PMCON control
+  {$define _WRT_ALL      = $1FF9}  // 000h to 1FFh write protected, no addresses may be modified by PMCON control
+
+  // BORV : Brown-out Reset Voltage Selection
+  {$define _BORV_LO      = $1FFF}  // Brown-out Reset Voltage (Vbor), low trip point selected.
+  {$define _BORV_HI      = $1FF7}  // Brown-out Reset Voltage (Vbor), high trip point selected.
+
+  // LPBOR : Brown-out Reset Selection bits
+  {$define _LPBOR_ON     = $1FFF}  // BOR enabled
+  {$define _LPBOR_OFF    = $1FEF}  // BOR disabled
+
+  // LVP : Low-Voltage Programming Enable
+  {$define _LVP_ON       = $1FFF}  // Low-voltage programming enabled
+  {$define _LVP_OFF      = $1FDF}  // High-voltage on MCLR/VPP must be used for programming
+
+  // CP : Code Protection bit
+  {$define _CP_OFF       = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON        = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON     = $1FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF    = $1F7F}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF    = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON     = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable
+  {$define _WDTE_ON      = $1FFF}  // WDT enabled
+  {$define _WDTE_NSLEEP  = $1DFF}  // WDT enabled while running and disabled in Sleep
+  {$define _WDTE_SWDTEN  = $1BFF}  // WDT controlled by the SWDTEN bit in the WDTCON register
+  {$define _WDTE_OFF     = $19FF}  // WDT disabled
+
+  // BOREN : Brown-out Reset Enable
+  {$define _BOREN_ON     = $1FFF}  // Brown-out Reset enabled
+  {$define _BOREN_NSLEEP = $17FF}  // Brown-out Reset enabled while running and disabled in Sleep
+  {$define _BOREN_SBODEN = $0FFF}  // Brown-out Reset controlled by the SBOREN bit in the BORCON register
+  {$define _BOREN_OFF    = $07FF}  // Brown-out Reset disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_INTOSC  = $1FFF}  // INTOSC oscillator: CLKIN function disabled
+  {$define _FOSC_EC      = $3FFF}  // EC: CLKIN function enabled
+
+implementation
+end.

--- a/PIC12F609.pas
+++ b/PIC12F609.pas
@@ -1,0 +1,219 @@
+unit PIC12F609;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F609'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_GPIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_GPIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  VRCON             : byte absolute $0019;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_VRR         : bit  absolute VRCON.6;
+  VRCON_FBREN       : bit  absolute VRCON.5;
+  VRCON_VR2         : bit  absolute VRCON.4;
+  VRCON_VR1         : bit  absolute VRCON.3;
+  VRCON_VR0         : bit  absolute VRCON.2;
+  CMCON0            : byte absolute $001a;
+  CMCON0_C1ON       : bit  absolute CMCON0.6;
+  CMCON0_C1OUT      : bit  absolute CMCON0.5;
+  CMCON0_C1OE       : bit  absolute CMCON0.4;
+  CMCON0_C1POL      : bit  absolute CMCON0.3;
+  CMCON0_C1R        : bit  absolute CMCON0.2;
+  CMCON0_C1CH       : bit  absolute CMCON0.1;
+  CMCON1            : byte absolute $001c;
+  CMCON1_T1ACS      : bit  absolute CMCON1.4;
+  CMCON1_C1HYS      : bit  absolute CMCON1.3;
+  CMCON1_T1GSS      : bit  absolute CMCON1.2;
+  CMCON1_C1SYNC     : bit  absolute CMCON1.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_GPPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  WPU               : byte absolute $0095;
+  WPU_WPUA5         : bit  absolute WPU.5;
+  WPU_WPUA4         : bit  absolute WPU.4;
+  WPU_WPUA2         : bit  absolute WPU.3;
+  WPU_WPUA1         : bit  absolute WPU.2;
+  WPU_WPUA0         : bit  absolute WPU.1;
+  IOC               : byte absolute $0096;
+  IOC_IOC5          : bit  absolute IOC.5;
+  IOC_IOC4          : bit  absolute IOC.4;
+  IOC_IOC3          : bit  absolute IOC.3;
+  IOC_IOC2          : bit  absolute IOC.2;
+  IOC_IOC1          : bit  absolute IOC.1;
+  IOC_IOC0          : bit  absolute IOC.0;
+  ANSEL             : byte absolute $009f;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS1        : bit  absolute ANSEL.2;
+  ANSEL_ANS0        : bit  absolute ANSEL.1;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '019-01A:SFR'}  // VRCON, CMCON0
+  {$SET_STATE_RAM '01C-01C:SFR'}  // CMCON1
+  {$SET_STATE_RAM '040-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-090:SFR'}  // OSCTUNE
+  {$SET_STATE_RAM '095-096:SFR'}  // WPU, IOC
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ANSEL
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:09'} // PIR1
+  {$SET_UNIMP_BITS '019:BF'} // VRCON
+  {$SET_UNIMP_BITS '01A:F5'} // CMCON0
+  {$SET_UNIMP_BITS '01C:1B'} // CMCON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:09'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPU
+  {$SET_UNIMP_BITS '096:3F'} // IOC
+  {$SET_UNIMP_BITS '09F:7F'} // ANSEL
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/OSC1/CLKIN
+  // Pin  3 : GP4/C1IN-/T1G/OSC2/CLKOUT
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/T0CKI/INT/C1OUT
+  // Pin  6 : GP1/C1IN0-/ICSPCLK
+  // Pin  7 : GP0/C1IN+/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $03FF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $03FE}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $03FC}  // BOR disabled
+
+  // IOSCFS : Internal Oscillator Frequency Select
+  {$define _IOSCFS_8MHZ    = $03FF}  // 8 MHz
+  {$define _IOSCFS_4MHZ    = $03FB}  // 4 MHz
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $03FF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $03F7}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $03FF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $03EF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $03FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $03DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $03FF}  // WDT enabled
+  {$define _WDTE_OFF       = $03BF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $03FF}  // RC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $037F}  // RCIO oscillator: I/O function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $02FF}  // INTOSC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $027F}  // INTOSCIO oscillator: I/O function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_EC        = $01FF}  // EC: I/O function on GP4/OSC2/CLKOUT pin, CLKIN on GP5/OSC1/CLKIN
+  {$define _FOSC_HS        = $017F}  // HS oscillator: High-speed crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_XT        = $00FF}  // XT oscillator: Crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_LP        = $007F}  // LP oscillator: Low-power crystal on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC12F615.pas
+++ b/PIC12F615.pas
@@ -1,0 +1,286 @@
+unit PIC12F615;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F615'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_GPIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_GPIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.5;
+  PIR1_ECCPIF       : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS1     : bit  absolute T2CON.1;
+  T2CON_T2CKPS0     : bit  absolute T2CON.0;
+  CCPR1L            : byte absolute $0013;
+  CCPR1H            : byte absolute $0014;
+  CCP1CON           : byte absolute $0015;
+  CCP1CON_P1M       : bit  absolute CCP1CON.7;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  PWM1CON           : byte absolute $0016;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $0017;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  VRCON             : byte absolute $0019;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_VRR         : bit  absolute VRCON.6;
+  VRCON_FBREN       : bit  absolute VRCON.5;
+  VRCON_VR2         : bit  absolute VRCON.4;
+  VRCON_VR1         : bit  absolute VRCON.3;
+  VRCON_VR0         : bit  absolute VRCON.2;
+  CMCON0            : byte absolute $001a;
+  CMCON0_C1ON       : bit  absolute CMCON0.6;
+  CMCON0_C1OUT      : bit  absolute CMCON0.5;
+  CMCON0_C1OE       : bit  absolute CMCON0.4;
+  CMCON0_C1POL      : bit  absolute CMCON0.3;
+  CMCON0_C1R        : bit  absolute CMCON0.2;
+  CMCON0_C1CH       : bit  absolute CMCON0.1;
+  CMCON1            : byte absolute $001c;
+  CMCON1_T1ACS      : bit  absolute CMCON1.4;
+  CMCON1_C1HYS      : bit  absolute CMCON1.3;
+  CMCON1_T1GSS      : bit  absolute CMCON1.2;
+  CMCON1_C1SYNC     : bit  absolute CMCON1.1;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_GPPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.5;
+  PIE1_ECCPIE       : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  APFCON            : byte absolute $0093;
+  APFCON_T1GSEL     : bit  absolute APFCON.4;
+  APFCON_P1BSEL     : bit  absolute APFCON.3;
+  APFCON_P1ASEL     : bit  absolute APFCON.2;
+  WPU               : byte absolute $0095;
+  WPU_WPUA5         : bit  absolute WPU.5;
+  WPU_WPUA4         : bit  absolute WPU.4;
+  WPU_WPUA2         : bit  absolute WPU.3;
+  WPU_WPUA1         : bit  absolute WPU.2;
+  WPU_WPUA0         : bit  absolute WPU.1;
+  IOC               : byte absolute $0096;
+  IOC_IOC5          : bit  absolute IOC.5;
+  IOC_IOC4          : bit  absolute IOC.4;
+  IOC_IOC3          : bit  absolute IOC.3;
+  IOC_IOC2          : bit  absolute IOC.2;
+  IOC_IOC1          : bit  absolute IOC.1;
+  IOC_IOC0          : bit  absolute IOC.0;
+  ADRESL            : byte absolute $009e;
+  ANSEL             : byte absolute $009f;
+  ANSEL_ADCS2       : bit  absolute ANSEL.6;
+  ANSEL_ADCS1       : bit  absolute ANSEL.5;
+  ANSEL_ADCS0       : bit  absolute ANSEL.4;
+  ANSEL_AN3         : bit  absolute ANSEL.3;
+  ANSEL_AN2         : bit  absolute ANSEL.2;
+  ANSEL_AN1         : bit  absolute ANSEL.1;
+  ANSEL_AN0         : bit  absolute ANSEL.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-017:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, CCPR1L, CCPR1H, CCP1CON, PWM1CON, ECCPAS
+  {$SET_STATE_RAM '019-01A:SFR'}  // VRCON, CMCON0
+  {$SET_STATE_RAM '01C-01C:SFR'}  // CMCON1
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '040-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-090:SFR'}  // OSCTUNE
+  {$SET_STATE_RAM '092-093:SFR'}  // PR2, APFCON
+  {$SET_STATE_RAM '095-096:SFR'}  // WPU, IOC
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ANSEL
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:6B'} // PIR1
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '015:BF'} // CCP1CON
+  {$SET_UNIMP_BITS '019:BF'} // VRCON
+  {$SET_UNIMP_BITS '01A:F5'} // CMCON0
+  {$SET_UNIMP_BITS '01C:1B'} // CMCON1
+  {$SET_UNIMP_BITS '01F:DF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:6B'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:13'} // APFCON
+  {$SET_UNIMP_BITS '095:37'} // WPU
+  {$SET_UNIMP_BITS '096:3F'} // IOC
+  {$SET_UNIMP_BITS '09F:7F'} // ANSEL
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/P1A/OSC1/CLKIN
+  // Pin  3 : GP4/AN3/C1IN1-/T1G/P1B/OSC2/CLKOUT
+  // Pin  4 : GP3/T1G/MCLR/Vpp
+  // Pin  5 : GP2/AN2/T0CKI/INT/C1OUT/CCP1/P1A
+  // Pin  6 : GP1/AN1/C1IN0-/Vref/ICSPCLK
+  // Pin  7 : GP0/AN0/C1IN+/P1B/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $03FF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $03FE}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $03FC}  // BOR disabled
+
+  // IOSCFS : Internal Oscillator Frequency Select
+  {$define _IOSCFS_8MHZ    = $03FF}  // 8 MHz
+  {$define _IOSCFS_4MHZ    = $03FB}  // 4 MHz
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $03FF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $03F7}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $03FF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $03EF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $03FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $03DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $03FF}  // WDT enabled
+  {$define _WDTE_OFF       = $03BF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $03FF}  // RC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $037F}  // RCIO oscillator: I/O function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $02FF}  // INTOSC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $027F}  // INTOSCIO oscillator: I/O function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_EC        = $01FF}  // EC: I/O function on GP4/OSC2/CLKOUT pin, CLKIN on GP5/OSC1/CLKIN
+  {$define _FOSC_HS        = $017F}  // HS oscillator: High-speed crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_XT        = $00FF}  // XT oscillator: Crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_LP        = $007F}  // LP oscillator: Low-power crystal on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC12F617.pas
+++ b/PIC12F617.pas
@@ -1,0 +1,325 @@
+unit PIC12F617;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F617'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_GPIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_GPIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.5;
+  PIR1_CCP1IF       : bit  absolute PIR1.4;
+  PIR1_CMIF         : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0013;
+  CCPR1H            : byte absolute $0014;
+  CCP1CON           : byte absolute $0015;
+  CCP1CON_P1M       : bit  absolute CCP1CON.7;
+  CCP1CON_DCB1      : bit  absolute CCP1CON.5;
+  CCP1CON_DCB0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  PWM1CON           : byte absolute $0016;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $0017;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  VRCON             : byte absolute $0019;
+  VRCON_CMVREN      : bit  absolute VRCON.7;
+  VRCON_VRR         : bit  absolute VRCON.6;
+  VRCON_FVREN       : bit  absolute VRCON.5;
+  VRCON_VR1         : bit  absolute VRCON.4;
+  VRCON_VR0         : bit  absolute VRCON.3;
+  CMCON0            : byte absolute $001a;
+  CMCON0_CMON       : bit  absolute CMCON0.6;
+  CMCON0_COUT       : bit  absolute CMCON0.5;
+  CMCON0_CMOE       : bit  absolute CMCON0.4;
+  CMCON0_CMPOL      : bit  absolute CMCON0.3;
+  CMCON0_CMR        : bit  absolute CMCON0.2;
+  CMCON0_CMCH       : bit  absolute CMCON0.1;
+  CMCON1            : byte absolute $001c;
+  CMCON1_T1ACS      : bit  absolute CMCON1.4;
+  CMCON1_CMHYS      : bit  absolute CMCON1.3;
+  CMCON1_T1GSS      : bit  absolute CMCON1.2;
+  CMCON1_CMSYNC     : bit  absolute CMCON1.1;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_GPPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.5;
+  PIE1_CCP1IE       : bit  absolute PIE1.4;
+  PIE1_CMIE         : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  APFCON            : byte absolute $0093;
+  APFCON_T1GSEL     : bit  absolute APFCON.4;
+  APFCON_P1BSEL     : bit  absolute APFCON.3;
+  APFCON_P1ASEL     : bit  absolute APFCON.2;
+  WPU               : byte absolute $0095;
+  WPU_WPU5          : bit  absolute WPU.5;
+  WPU_WPU4          : bit  absolute WPU.4;
+  WPU_WPU2          : bit  absolute WPU.3;
+  WPU_WPU1          : bit  absolute WPU.2;
+  WPU_WPU0          : bit  absolute WPU.1;
+  IOC               : byte absolute $0096;
+  IOC_IOC5          : bit  absolute IOC.5;
+  IOC_IOC4          : bit  absolute IOC.4;
+  IOC_IOC3          : bit  absolute IOC.3;
+  IOC_IOC2          : bit  absolute IOC.2;
+  IOC_IOC1          : bit  absolute IOC.1;
+  IOC_IOC0          : bit  absolute IOC.0;
+  PMCON1            : byte absolute $0098;
+  PMCON1_WREN       : bit  absolute PMCON1.2;
+  PMCON1_WR         : bit  absolute PMCON1.1;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+  PMCON2            : byte absolute $0099;
+  PMADRL            : byte absolute $009a;
+  PMADRL_PMADRL7    : bit  absolute PMADRL.7;
+  PMADRL_PMADRL6    : bit  absolute PMADRL.6;
+  PMADRL_PMADRL5    : bit  absolute PMADRL.5;
+  PMADRL_PMADRL4    : bit  absolute PMADRL.4;
+  PMADRL_PMADRL3    : bit  absolute PMADRL.3;
+  PMADRL_PMADRL2    : bit  absolute PMADRL.2;
+  PMADRL_PMADRL1    : bit  absolute PMADRL.1;
+  PMADRL_PMADRL0    : bit  absolute PMADRL.0;
+  PMADRH            : byte absolute $009b;
+  PMADRH_PMADRH2    : bit  absolute PMADRH.2;
+  PMADRH_PMADRH1    : bit  absolute PMADRH.1;
+  PMADRH_PMADRH0    : bit  absolute PMADRH.0;
+  PMDATL            : byte absolute $009c;
+  PMDATL_PMDATL7    : bit  absolute PMDATL.7;
+  PMDATL_PMDATL6    : bit  absolute PMDATL.6;
+  PMDATL_PMDATL5    : bit  absolute PMDATL.5;
+  PMDATL_PMDATL4    : bit  absolute PMDATL.4;
+  PMDATL_PMDATL3    : bit  absolute PMDATL.3;
+  PMDATL_PMDATL2    : bit  absolute PMDATL.2;
+  PMDATL_PMDATL1    : bit  absolute PMDATL.1;
+  PMDATL_PMDATL0    : bit  absolute PMDATL.0;
+  PMDATH            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ANSEL             : byte absolute $009f;
+  ANSEL_ADCS2       : bit  absolute ANSEL.6;
+  ANSEL_ADCS1       : bit  absolute ANSEL.5;
+  ANSEL_ADCS0       : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-017:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, CCPR1L, CCPR1H, CCP1CON, PWM1CON, ECCPAS
+  {$SET_STATE_RAM '019-01A:SFR'}  // VRCON, CMCON0
+  {$SET_STATE_RAM '01C-01C:SFR'}  // CMCON1
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-090:SFR'}  // OSCTUNE
+  {$SET_STATE_RAM '092-093:SFR'}  // PR2, APFCON
+  {$SET_STATE_RAM '095-096:SFR'}  // WPU, IOC
+  {$SET_STATE_RAM '098-09F:SFR'}  // PMCON1, PMCON2, PMADRL, PMADRH, PMDATL, PMDATH, ADRESL, ANSEL
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:6B'} // PIR1
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '015:BF'} // CCP1CON
+  {$SET_UNIMP_BITS '019:BF'} // VRCON
+  {$SET_UNIMP_BITS '01A:F5'} // CMCON0
+  {$SET_UNIMP_BITS '01C:1B'} // CMCON1
+  {$SET_UNIMP_BITS '01F:DF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:6B'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:13'} // APFCON
+  {$SET_UNIMP_BITS '095:37'} // WPU
+  {$SET_UNIMP_BITS '096:3F'} // IOC
+  {$SET_UNIMP_BITS '098:00'} // PMCON1
+  {$SET_UNIMP_BITS '099:00'} // PMCON2
+  {$SET_UNIMP_BITS '09A:00'} // PMADRL
+  {$SET_UNIMP_BITS '09B:00'} // PMADRH
+  {$SET_UNIMP_BITS '09C:00'} // PMDATL
+  {$SET_UNIMP_BITS '09D:00'} // PMDATH
+  {$SET_UNIMP_BITS '09F:7F'} // ANSEL
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/P1A/OSC1/CLKIN
+  // Pin  3 : GP4/AN3/C1IN1-/T1G/P1B/OSC2/CLKOUT
+  // Pin  4 : GP3/T1G/MCLR/Vpp
+  // Pin  5 : GP2/AN2/T0CKI/INT/C1OUT/CCP1/P1A
+  // Pin  6 : GP1/AN1/C1IN0-/Vref/ICSPCLK
+  // Pin  7 : GP0/AN0/C1IN+/P1B/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // WRT : Flash Program Memory Self Write Enable bits
+  {$define _WRT_OFF        = $0FFF}  // Write protection off
+  {$define _WRT_BOOT       = $0FFE}  // 000h to 1FFh write protected, 200h to 7FFh may be modified by PMCON1 control
+  {$define _WRT_HALF       = $0FFD}  // 000h to 3FFh write protected, 400h to 7FFh may be modified by PMCON1 control
+  {$define _WRT_ALL        = $0FFC}  // 000h to 7FFh write protected, entire program memory is write protected.
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $0FF3}  // BOR disabled
+
+  // IOSCFS : Internal Oscillator Frequency Select
+  {$define _IOSCFS_8MHZ    = $0FFF}  // 8 MHz
+  {$define _IOSCFS_4MHZ    = $0FEF}  // 4 MHz
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $0FFF}  // Program memory is not code protected
+  {$define _CP_ON          = $0FDF}  // Program memory is external read and write protected
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $0FFF}  // MCLR pin is MCLR function and weak internal pull-up is enabled
+  {$define _MCLRE_OFF      = $0FBF}  // MCLR pin is alternate function, MCLR function is internally disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $0FFF}  // EXTRC oscillator: CLKOUT function on RA4/AN3/T1G/OSC2/CLKOUT, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $0DFF}  // EXTRCIO oscillator: I/O function on RA4/AN3/T1G/OSC2/CLKOUT, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/AN3/T1G/OSC2/CLKOUT, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/AN3/T1G/OSC2/CLKOUT, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EC        = $07FF}  // EC: I/O function on RA4/AN3/T1G/OSC2/CLKOUT, CLKIN on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_HS        = $05FF}  // HS oscillator: High-speed crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/AN3/T1G/OSC2/CLKOUT
+  {$define _FOSC_XT        = $03FF}  // XT oscillator: Crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/AN3/T1G/OSC2/CLKOUT
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA5/T1CKI/OSC1/CLKIN and RA4/AN3/T1G/OSC2/CLKOUT
+
+implementation
+end.

--- a/PIC12F629.pas
+++ b/PIC12F629.pas
@@ -1,0 +1,228 @@
+unit PIC12F629;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F629'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_GPIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_GPIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.5;
+  PIR1_ADIF         : bit  absolute PIR1.4;
+  PIR1_CMIF         : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  CMCON             : byte absolute $0019;
+  CMCON_COUT        : bit  absolute CMCON.6;
+  CMCON_CINV        : bit  absolute CMCON.5;
+  CMCON_CIS         : bit  absolute CMCON.4;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_GPPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.5;
+  PIE1_ADIE         : bit  absolute PIE1.4;
+  PIE1_CMIE         : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCAL            : byte absolute $0090;
+  OSCCAL_CAL5       : bit  absolute OSCCAL.7;
+  OSCCAL_CAL4       : bit  absolute OSCCAL.6;
+  OSCCAL_CAL3       : bit  absolute OSCCAL.5;
+  OSCCAL_CAL2       : bit  absolute OSCCAL.4;
+  OSCCAL_CAL1       : bit  absolute OSCCAL.3;
+  OSCCAL_CAL0       : bit  absolute OSCCAL.2;
+  WPU               : byte absolute $0095;
+  WPU_WPU5          : bit  absolute WPU.5;
+  WPU_WPU4          : bit  absolute WPU.4;
+  WPU_WPU2          : bit  absolute WPU.3;
+  WPU_WPU1          : bit  absolute WPU.2;
+  WPU_WPU0          : bit  absolute WPU.1;
+  IOC               : byte absolute $0096;
+  IOC_IOC5          : bit  absolute IOC.5;
+  IOC_IOC4          : bit  absolute IOC.4;
+  IOC_IOC3          : bit  absolute IOC.3;
+  IOC_IOC2          : bit  absolute IOC.2;
+  IOC_IOC1          : bit  absolute IOC.1;
+  IOC_IOC0          : bit  absolute IOC.0;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '019-019:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-05F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-090:SFR'}  // OSCCAL
+  {$SET_STATE_RAM '095-096:SFR'}  // WPU, IOC
+  {$SET_STATE_RAM '099-09D:SFR'}  // VRCON, EEDATA, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '0A0-0DF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:C9'} // PIR1
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '019:5F'} // CMCON
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:C9'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:FC'} // OSCCAL
+  {$SET_UNIMP_BITS '095:37'} // WPU
+  {$SET_UNIMP_BITS '096:3F'} // IOC
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09B:7F'} // EEADR
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/OSC1/CLKIN
+  // Pin  3 : GP4/T1G/OSC2/CLKOUT
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/T0CKI/INT/COUT
+  // Pin  6 : GP1/CIN-/ICSPCLK
+  // Pin  7 : GP0/CIN+/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // BG : Bandgap Calibration bits for BOD and POR voltage
+  {$define _BG_           = $31FF}  // Highest bandgap voltage
+  {$define _BG_           = $31FC}  // Lowest bandgap voltage
+
+  // Reserved : Reserved
+  {$define _Reserved_     = $31E3}  // Reserved
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $31FF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $31DF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $31FF}  // Program Memory code protection is disabled
+  {$define _CP_ON         = $31BF}  // Program Memory code protection is enabled
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON      = $31FF}  // BOD enabled
+  {$define _BOREN_OFF     = $317F}  // BOD disabled
+
+  // MCLRE : GP3/MCLR pin function select
+  {$define _MCLRE_ON      = $31FF}  // GP3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $30FF}  // GP3/MCLR pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-Up Timer Enable bit
+  {$define _PWRTE_OFF     = $33FF}  // PWRT disabled
+  {$define _PWRTE_ON      = $31FF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $35FF}  // WDT enabled
+  {$define _WDTE_OFF      = $31FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $39FF}  // RC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $31FF}  // RC oscillator: I/O function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $29FF}  // INTOSC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $21FF}  // INTOSC oscillator: I/O function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_EC       = $19FF}  // EC: I/O function on GP4/OSC2/CLKOUT pin, CLKIN on GP5/OSC1/CLKIN
+  {$define _FOSC_HS       = $11FF}  // HS oscillator: High speed crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_XT       = $09FF}  // XT oscillator: Crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low power crystal on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC12F635.pas
+++ b/PIC12F635.pas
@@ -1,0 +1,296 @@
+unit PIC12F635;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F635'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.6;
+  PIR1_LVDIF        : bit  absolute PIR1.5;
+  PIR1_CRIF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_OSFIF        : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CMCON0            : byte absolute $0019;
+  CMCON0_COUT       : bit  absolute CMCON0.6;
+  CMCON0_CINV       : bit  absolute CMCON0.5;
+  CMCON0_CIS        : bit  absolute CMCON0.4;
+  CMCON0_CM0        : bit  absolute CMCON0.3;
+  CMCON1            : byte absolute $001a;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_CMSYNC     : bit  absolute CMCON1.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.6;
+  PIE1_LVDIE        : bit  absolute PIE1.5;
+  PIE1_CRIE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_OSFIE        : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_WUR          : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  LVDCON            : byte absolute $0094;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.3;
+  LVDCON_LVDL1      : bit  absolute LVDCON.2;
+  LVDCON_LVDL0      : bit  absolute LVDCON.1;
+  WPUDA             : byte absolute $0095;
+  WPUDA_WPUDA5      : bit  absolute WPUDA.5;
+  WPUDA_WPUDA4      : bit  absolute WPUDA.4;
+  WPUDA_WPUDA2      : bit  absolute WPUDA.3;
+  WPUDA_WPUDA1      : bit  absolute WPUDA.2;
+  WPUDA_WPUDA0      : bit  absolute WPUDA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDA               : byte absolute $0097;
+  WDA_WDA5          : bit  absolute WDA.5;
+  WDA_WDA4          : bit  absolute WDA.4;
+  WDA_WDA2          : bit  absolute WDA.3;
+  WDA_WDA1          : bit  absolute WDA.2;
+  WDA_WDA0          : bit  absolute WDA.1;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  CRCON             : byte absolute $0110;
+  CRCON_GO_nDONE    : bit  absolute CRCON.7;
+  CRCON_ENC_nDEC    : bit  absolute CRCON.6;
+  CRCON_CRREG1      : bit  absolute CRCON.5;
+  CRCON_CRREG0      : bit  absolute CRCON.4;
+  CRDAT0            : byte absolute $0111;
+  CRDAT1            : byte absolute $0112;
+  CRDAT2            : byte absolute $0113;
+  CRDAT3            : byte absolute $0114;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '018-01A:SFR'}  // WDTCON, CMCON0, CMCON1
+  {$SET_STATE_RAM '040-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-090:SFR'}  // PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '094-097:SFR'}  // LVDCON, WPUDA, IOCA, WDA
+  {$SET_STATE_RAM '099-09D:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-105:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '110-114:SFR'}  // CRCON, CRDAT0, CRDAT1, CRDAT2, CRDAT3
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-185:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-105:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-185:bnk1'} // TRISIO
+  {$SET_MAPPED_RAM '18A-18A:bnk1'} // PCLATH
+  {$SET_MAPPED_RAM '18B-18B:bnk0'} // INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:ED'} // PIR1
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '019:5F'} // CMCON0
+  {$SET_UNIMP_BITS '01A:02'} // CMCON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:ED'} // PIE1
+  {$SET_UNIMP_BITS '08E:3B'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '094:37'} // LVDCON
+  {$SET_UNIMP_BITS '095:37'} // WPUDA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:37'} // WDA
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '110:C3'} // CRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/OSC1/CLKIN
+  // Pin  3 : GP4/T1G/OSC2/CLKOUT
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/T0CKI/INT/C1OUT
+  // Pin  6 : GP1/C1IN-/ICSPCLK
+  // Pin  7 : GP0/C1IN+/ICSPDAT/ULPWU
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // WURE : Wake-Up Reset Enable bit
+  {$define _WURE_OFF       = $1FFF}  // Standard wake-up and continue enabled
+  {$define _WURE_ON        = $1FFE}  // Wake-up and Reset enabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor disabled
+
+  // IESO : Internal-External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal External Switchover mode disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOD enabled and SBOdEN bit disabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOD enabled while running and disabled in Sleep. SBODEN bit disabled.
+  {$define _BOREN_SBODEN   = $1FEF}  // SBODEN controls BOD function
+  {$define _BOREN_OFF      = $1FE7}  // BOD and SBODEN disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory is not code protected
+  {$define _CPD_ON         = $1FDF}  // Data memory is external read protected
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory is not code protected
+  {$define _CP_ON          = $1FBF}  // Program memory is external read and write-protected
+
+  // MCLRE : MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // MCLR pin is MCLR function and weak internal pull-up is enabled
+  {$define _MCLRE_OFF      = $1F7F}  // MCLR pin function is alternate function, MCLR function is internally disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA4/T1G/OSC2/CLKOUT pin, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA4/T1G/OSC2/CLKOUT pin, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA4/T1G/OSC2/CLKOUT pin, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA4/T1G/OSC2/CLKOUT pin, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA4/T1G/OSC2/CLKOUT, CLKIN on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+
+implementation
+end.

--- a/PIC12F675.pas
+++ b/PIC12F675.pas
@@ -1,0 +1,247 @@
+unit PIC12F675;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F675'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_GPIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_GPIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.5;
+  PIR1_ADIF         : bit  absolute PIR1.4;
+  PIR1_CMIF         : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  CMCON             : byte absolute $0019;
+  CMCON_COUT        : bit  absolute CMCON.6;
+  CMCON_CINV        : bit  absolute CMCON.5;
+  CMCON_CIS         : bit  absolute CMCON.4;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.3;
+  ADCON0_ADON       : bit  absolute ADCON0.2;
+  ADCON0_GO_DONE    : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_GPPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.5;
+  PIE1_ADIE         : bit  absolute PIE1.4;
+  PIE1_CMIE         : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCAL            : byte absolute $0090;
+  OSCCAL_CAL5       : bit  absolute OSCCAL.7;
+  OSCCAL_CAL4       : bit  absolute OSCCAL.6;
+  OSCCAL_CAL3       : bit  absolute OSCCAL.5;
+  OSCCAL_CAL2       : bit  absolute OSCCAL.4;
+  OSCCAL_CAL1       : bit  absolute OSCCAL.3;
+  OSCCAL_CAL0       : bit  absolute OSCCAL.2;
+  WPU               : byte absolute $0095;
+  WPU_WPU5          : bit  absolute WPU.5;
+  WPU_WPU4          : bit  absolute WPU.4;
+  WPU_WPU2          : bit  absolute WPU.3;
+  WPU_WPU1          : bit  absolute WPU.2;
+  WPU_WPU0          : bit  absolute WPU.1;
+  IOC               : byte absolute $0096;
+  IOC_IOC5          : bit  absolute IOC.5;
+  IOC_IOC4          : bit  absolute IOC.4;
+  IOC_IOC3          : bit  absolute IOC.3;
+  IOC_IOC2          : bit  absolute IOC.2;
+  IOC_IOC1          : bit  absolute IOC.1;
+  IOC_IOC0          : bit  absolute IOC.0;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ANSEL             : byte absolute $009f;
+  ANSEL_ADCS2       : bit  absolute ANSEL.6;
+  ANSEL_ADCS1       : bit  absolute ANSEL.5;
+  ANSEL_ADCS0       : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '019-019:SFR'}  // CMCON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-05F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-090:SFR'}  // OSCCAL
+  {$SET_STATE_RAM '095-096:SFR'}  // WPU, IOC
+  {$SET_STATE_RAM '099-09F:SFR'}  // VRCON, EEDATA, EEADR, EECON1, EECON2, ADRESL, ANSEL
+  {$SET_STATE_RAM '0A0-0DF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:C9'} // PIR1
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '019:5F'} // CMCON
+  {$SET_UNIMP_BITS '01F:CF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:C9'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:FC'} // OSCCAL
+  {$SET_UNIMP_BITS '095:37'} // WPU
+  {$SET_UNIMP_BITS '096:3F'} // IOC
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09B:7F'} // EEADR
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:7F'} // ANSEL
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/OSC1/CLKIN
+  // Pin  3 : GP4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/AN2/T0CKI/INT/COUT
+  // Pin  6 : GP1/AN1/CIN-/Vref/ICSPCLK
+  // Pin  7 : GP0/AN0/CIN+/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // BG : Bandgap Calibration bits for BOD and POR voltage
+  {$define _BG_           = $31FF}  // Highest bandgap voltage
+  {$define _BG_           = $31FC}  // Lowest bandgap voltage
+
+  // Reserved : Reserved
+  {$define _Reserved_     = $31E3}  // Reserved
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $31FF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $31DF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $31FF}  // Program Memory code protection is disabled
+  {$define _CP_ON         = $31BF}  // Program Memory code protection is enabled
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON      = $31FF}  // BOD enabled
+  {$define _BOREN_OFF     = $317F}  // BOD disabled
+
+  // MCLRE : GP3/MCLR pin function select
+  {$define _MCLRE_ON      = $31FF}  // GP3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $30FF}  // GP3/MCLR pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-Up Timer Enable bit
+  {$define _PWRTE_OFF     = $33FF}  // PWRT disabled
+  {$define _PWRTE_ON      = $31FF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $35FF}  // WDT enabled
+  {$define _WDTE_OFF      = $31FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $39FF}  // RC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $31FF}  // RC oscillator: I/O function on GP4/OSC2/CLKOUT pin, RC on GP5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $29FF}  // INTOSC oscillator: CLKOUT function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $21FF}  // INTOSC oscillator: I/O function on GP4/OSC2/CLKOUT pin, I/O function on GP5/OSC1/CLKIN
+  {$define _FOSC_EC       = $19FF}  // EC: I/O function on GP4/OSC2/CLKOUT pin, CLKIN on GP5/OSC1/CLKIN
+  {$define _FOSC_HS       = $11FF}  // HS oscillator: High speed crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_XT       = $09FF}  // XT oscillator: Crystal/resonator on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low power crystal on GP4/OSC2/CLKOUT and GP5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC12F683.pas
+++ b/PIC12F683.pas
@@ -1,0 +1,298 @@
+unit PIC12F683;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F683'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  GPIO              : byte absolute $0005;
+  GPIO_GP5          : bit  absolute GPIO.5;
+  GPIO_GP4          : bit  absolute GPIO.4;
+  GPIO_GP3          : bit  absolute GPIO.3;
+  GPIO_GP2          : bit  absolute GPIO.2;
+  GPIO_GP1          : bit  absolute GPIO.1;
+  GPIO_GP0          : bit  absolute GPIO.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_GPIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_GPIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_CCP1IF       : bit  absolute PIR1.5;
+  PIR1_CMIF         : bit  absolute PIR1.4;
+  PIR1_OSFIF        : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0013;
+  CCPR1H            : byte absolute $0014;
+  CCP1CON           : byte absolute $0015;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CMCON0            : byte absolute $0019;
+  CMCON0_COUT       : bit  absolute CMCON0.6;
+  CMCON0_CINV       : bit  absolute CMCON0.5;
+  CMCON0_CIS        : bit  absolute CMCON0.4;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  CMCON1            : byte absolute $001a;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_CMSYNC     : bit  absolute CMCON1.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.3;
+  ADCON0_ADON       : bit  absolute ADCON0.2;
+  ADCON0_GO         : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_GPPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISIO            : byte absolute $0085;
+  TRISIO_TRISIO5    : bit  absolute TRISIO.5;
+  TRISIO_TRISIO4    : bit  absolute TRISIO.4;
+  TRISIO_TRISIO3    : bit  absolute TRISIO.3;
+  TRISIO_TRISIO2    : bit  absolute TRISIO.2;
+  TRISIO_TRISIO1    : bit  absolute TRISIO.1;
+  TRISIO_TRISIO0    : bit  absolute TRISIO.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_CCP1IE       : bit  absolute PIE1.5;
+  PIE1_CMIE         : bit  absolute PIE1.4;
+  PIE1_OSFIE        : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBODEN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOD          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  WPU               : byte absolute $0095;
+  WPU_WPU5          : bit  absolute WPU.5;
+  WPU_WPU4          : bit  absolute WPU.4;
+  WPU_WPU2          : bit  absolute WPU.3;
+  WPU_WPU1          : bit  absolute WPU.2;
+  WPU_WPU0          : bit  absolute WPU.1;
+  IOC               : byte absolute $0096;
+  IOC_IOC5          : bit  absolute IOC.5;
+  IOC_IOC4          : bit  absolute IOC.4;
+  IOC_IOC3          : bit  absolute IOC.3;
+  IOC_IOC2          : bit  absolute IOC.2;
+  IOC_IOC1          : bit  absolute IOC.1;
+  IOC_IOC0          : bit  absolute IOC.0;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ANSEL             : byte absolute $009f;
+  ANSEL_ADCS2       : bit  absolute ANSEL.6;
+  ANSEL_ADCS1       : bit  absolute ANSEL.5;
+  ANSEL_ADCS0       : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, GPIO
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-015:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '018-01A:SFR'}  // WDTCON, CMCON0, CMCON1
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISIO
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-090:SFR'}  // PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '095-096:SFR'}  // WPU, IOC
+  {$SET_STATE_RAM '099-09F:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2, ADRESL, ANSEL
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // GPIO
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:EF'} // PIR1
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '015:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '019:5F'} // CMCON0
+  {$SET_UNIMP_BITS '01A:03'} // CMCON1
+  {$SET_UNIMP_BITS '01F:CF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISIO
+  {$SET_UNIMP_BITS '08C:EF'} // PIE1
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPU
+  {$SET_UNIMP_BITS '096:3F'} // IOC
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:7F'} // ANSEL
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/T1CKI/OSC1/CLKIN
+  // Pin  3 : GP4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/AN2/T0CKI/INT/COUT/CCP1
+  // Pin  6 : GP1/AN1/CIN-/Vref/ICSPCLK
+  // Pin  7 : GP0/AN0/CIN+/ICSPDAT/ULPWU
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF       = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown Out Detect
+  {$define _BOREN_ON       = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $0EFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $0FFF}  // EXTRC oscillator: External RC on RA5/OSC1/CLKIN, CLKOUT function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_EXTRCIO   = $0DFF}  // EXTRCIO oscillator: External RC on RA5/OSC1/CLKIN, I/O function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_INTOSCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC        = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS        = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT        = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKINT
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC12F752.pas
+++ b/PIC12F752.pas
@@ -1,0 +1,455 @@
+unit PIC12F752;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F752'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  IOCAF              : byte absolute $0008;
+  IOCAF_IOCAF5       : bit  absolute IOCAF.5;
+  IOCAF_IOCAF4       : bit  absolute IOCAF.4;
+  IOCAF_IOCAF3       : bit  absolute IOCAF.3;
+  IOCAF_IOCAF2       : bit  absolute IOCAF.2;
+  IOCAF_IOCAF1       : bit  absolute IOCAF.1;
+  IOCAF_IOCAF0       : bit  absolute IOCAF.0;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_IOCIE       : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_IOCIF       : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.5;
+  PIR1_ADIF          : bit  absolute PIR1.4;
+  PIR1_HLTMR1IF      : bit  absolute PIR1.3;
+  PIR1_TMR2IF        : bit  absolute PIR1.2;
+  PIR1_TMR1IF        : bit  absolute PIR1.1;
+  PIR2               : byte absolute $000d;
+  PIR2_C2IF          : bit  absolute PIR2.4;
+  PIR2_C1IF          : bit  absolute PIR2.3;
+  PIR2_COG1IF        : bit  absolute PIR2.2;
+  PIR2_CCP1IF        : bit  absolute PIR2.1;
+  TMR1L              : byte absolute $000f;
+  TMR1H              : byte absolute $0010;
+  T1CON              : byte absolute $0011;
+  T1CON_TMR1CS1      : bit  absolute T1CON.7;
+  T1CON_TMR1CS0      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1      : bit  absolute T1CON.5;
+  T1CON_T1CKPS0      : bit  absolute T1CON.4;
+  T1CON_reserved     : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  T1GCON             : byte absolute $0012;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  CCPR1L             : byte absolute $0013;
+  CCPR1H             : byte absolute $0014;
+  CCP1CON            : byte absolute $0015;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  ADRESL             : byte absolute $001c;
+  ADRESH             : byte absolute $001d;
+  ADCON0             : byte absolute $001e;
+  ADCON0_ADFM        : bit  absolute ADCON0.7;
+  ADCON0_VCFG        : bit  absolute ADCON0.6;
+  ADCON0_CHS3        : bit  absolute ADCON0.4;
+  ADCON0_CHS2        : bit  absolute ADCON0.3;
+  ADCON0_CHS1        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  ADCON1             : byte absolute $001f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RAPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  IOCAP              : byte absolute $0088;
+  IOCAP_IOCAP5       : bit  absolute IOCAP.5;
+  IOCAP_IOCAP4       : bit  absolute IOCAP.4;
+  IOCAP_IOCAP3       : bit  absolute IOCAP.3;
+  IOCAP_IOCAP2       : bit  absolute IOCAP.2;
+  IOCAP_IOCAP1       : bit  absolute IOCAP.1;
+  IOCAP_IOCAP0       : bit  absolute IOCAP.0;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.5;
+  PIE1_ADIE          : bit  absolute PIE1.4;
+  PIE1_HLTMR1IE      : bit  absolute PIE1.3;
+  PIE1_TMR2IE        : bit  absolute PIE1.2;
+  PIE1_TMR1IE        : bit  absolute PIE1.1;
+  PIE2               : byte absolute $008d;
+  PIE2_C2IE          : bit  absolute PIE2.4;
+  PIE2_C1IE          : bit  absolute PIE2.3;
+  PIE2_COG1IE        : bit  absolute PIE2.2;
+  PIE2_CCP1IE        : bit  absolute PIE2.1;
+  OSCCON             : byte absolute $008f;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_HTS         : bit  absolute OSCCON.2;
+  OSCCON_LTS         : bit  absolute OSCCON.1;
+  FVRCON             : byte absolute $0090;
+  FVRCON_FVREN       : bit  absolute FVRCON.7;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.6;
+  FVRCON_FVRBUFEN    : bit  absolute FVRCON.5;
+  FVRCON_FVRBUFSS    : bit  absolute FVRCON.4;
+  DACCON0            : byte absolute $0091;
+  DACCON0_DACEN      : bit  absolute DACCON0.5;
+  DACCON0_DACRNG     : bit  absolute DACCON0.4;
+  DACCON0_DACOE      : bit  absolute DACCON0.3;
+  DACCON0_DACPSS0    : bit  absolute DACCON0.2;
+  DACCON1            : byte absolute $0092;
+  DACCON1_DACR4      : bit  absolute DACCON1.4;
+  DACCON1_DACR3      : bit  absolute DACCON1.3;
+  DACCON1_DACR2      : bit  absolute DACCON1.2;
+  DACCON1_DACR1      : bit  absolute DACCON1.1;
+  DACCON1_DACR0      : bit  absolute DACCON1.0;
+  CM2CON0            : byte absolute $009b;
+  CM2CON0_C2ON       : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT      : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE       : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL      : bit  absolute CM2CON0.4;
+  CM2CON0_C2ZLF      : bit  absolute CM2CON0.3;
+  CM2CON0_C2SP       : bit  absolute CM2CON0.2;
+  CM2CON0_C2HYS      : bit  absolute CM2CON0.1;
+  CM2CON0_C2SYNC     : bit  absolute CM2CON0.0;
+  CM2CON1            : byte absolute $009c;
+  CM2CON1_C2INTP     : bit  absolute CM2CON1.7;
+  CM2CON1_C2INTN     : bit  absolute CM2CON1.6;
+  CM2CON1_C2PCH1     : bit  absolute CM2CON1.5;
+  CM2CON1_C2PCH0     : bit  absolute CM2CON1.4;
+  CM2CON1_C2NCH0     : bit  absolute CM2CON1.3;
+  CM1CON0            : byte absolute $009d;
+  CM1CON0_C1ON       : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT      : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE       : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL      : bit  absolute CM1CON0.4;
+  CM1CON0_C1ZLF      : bit  absolute CM1CON0.3;
+  CM1CON0_C1SP       : bit  absolute CM1CON0.2;
+  CM1CON0_C1HYS      : bit  absolute CM1CON0.1;
+  CM1CON0_C1SYNC     : bit  absolute CM1CON0.0;
+  CM1CON1            : byte absolute $009e;
+  CM1CON1_C1INTP     : bit  absolute CM1CON1.7;
+  CM1CON1_C1INTN     : bit  absolute CM1CON1.6;
+  CM1CON1_C1PCH1     : bit  absolute CM1CON1.5;
+  CM1CON1_C1PCH0     : bit  absolute CM1CON1.4;
+  CM1CON1_C1NCH0     : bit  absolute CM1CON1.3;
+  CMOUT              : byte absolute $009f;
+  CMOUT_MCOUT2       : bit  absolute CMOUT.1;
+  CMOUT_MCOUT1       : bit  absolute CMOUT.0;
+  LATA               : byte absolute $0105;
+  LATA_LATA5         : bit  absolute LATA.5;
+  LATA_LATA4         : bit  absolute LATA.4;
+  LATA_LATA2         : bit  absolute LATA.3;
+  LATA_LATA1         : bit  absolute LATA.2;
+  LATA_LATA0         : bit  absolute LATA.1;
+  IOCAN              : byte absolute $0108;
+  IOCAN_IOCAN5       : bit  absolute IOCAN.5;
+  IOCAN_IOCAN4       : bit  absolute IOCAN.4;
+  IOCAN_IOCAN3       : bit  absolute IOCAN.3;
+  IOCAN_IOCAN2       : bit  absolute IOCAN.2;
+  IOCAN_IOCAN1       : bit  absolute IOCAN.1;
+  IOCAN_IOCAN0       : bit  absolute IOCAN.0;
+  WPUA               : byte absolute $010c;
+  WPUA_WPUA5         : bit  absolute WPUA.5;
+  WPUA_WPUA4         : bit  absolute WPUA.4;
+  WPUA_WPUA3         : bit  absolute WPUA.3;
+  WPUA_WPUA2         : bit  absolute WPUA.2;
+  WPUA_WPUA1         : bit  absolute WPUA.1;
+  WPUA_WPUA0         : bit  absolute WPUA.0;
+  SLRCONA            : byte absolute $010d;
+  SLRCONA_SLRA2      : bit  absolute SLRCONA.2;
+  SLRCONA_SLRA0      : bit  absolute SLRCONA.1;
+  PCON               : byte absolute $010f;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  TMR2               : byte absolute $0110;
+  PR2                : byte absolute $0111;
+  T2CON              : byte absolute $0112;
+  T2CON_T2OUTPS3     : bit  absolute T2CON.6;
+  T2CON_T2OUTPS2     : bit  absolute T2CON.5;
+  T2CON_T2OUTPS1     : bit  absolute T2CON.4;
+  T2CON_T2OUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  HLTMR1             : byte absolute $0113;
+  HLTPR1             : byte absolute $0114;
+  HLT1CON0           : byte absolute $0115;
+  HLT1CON0_H1OUTPS3  : bit  absolute HLT1CON0.6;
+  HLT1CON0_H1OUTPS2  : bit  absolute HLT1CON0.5;
+  HLT1CON0_H1OUTPS1  : bit  absolute HLT1CON0.4;
+  HLT1CON0_H1OUTPS0  : bit  absolute HLT1CON0.3;
+  HLT1CON0_H1ON      : bit  absolute HLT1CON0.2;
+  HLT1CON0_H1CKPS0   : bit  absolute HLT1CON0.1;
+  HLT1CON1           : byte absolute $0116;
+  HLT1CON1_H1ERS2    : bit  absolute HLT1CON1.4;
+  HLT1CON1_H1ERS1    : bit  absolute HLT1CON1.3;
+  HLT1CON1_H1ERS0    : bit  absolute HLT1CON1.2;
+  HLT1CON1_H1FEREN   : bit  absolute HLT1CON1.1;
+  HLT1CON1_H1REREN   : bit  absolute HLT1CON1.0;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA2       : bit  absolute ANSELA.3;
+  ANSELA_ANSA1       : bit  absolute ANSELA.2;
+  ANSELA_ANSA0       : bit  absolute ANSELA.1;
+  APFCON             : byte absolute $0188;
+  APFCON_T1GSEL      : bit  absolute APFCON.4;
+  APFCON_COG1FSEL    : bit  absolute APFCON.3;
+  APFCON_COG1O1SEL   : bit  absolute APFCON.2;
+  APFCON_COG1O0SEL   : bit  absolute APFCON.1;
+  OSCTUNE            : byte absolute $0189;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_WREN        : bit  absolute PMCON1.3;
+  PMCON1_WR          : bit  absolute PMCON1.2;
+  PMCON1_RD          : bit  absolute PMCON1.1;
+  PMCON2             : byte absolute $018d;
+  PMADRL             : byte absolute $018e;
+  PMADRH             : byte absolute $018f;
+  PMDATL             : byte absolute $0190;
+  PMDATH             : byte absolute $0191;
+  COG1PH             : byte absolute $0192;
+  COG1PH_G1PH3       : bit  absolute COG1PH.3;
+  COG1PH_G1PH2       : bit  absolute COG1PH.2;
+  COG1PH_G1PH1       : bit  absolute COG1PH.1;
+  COG1PH_G1PH0       : bit  absolute COG1PH.0;
+  COG1BLK            : byte absolute $0193;
+  COG1BLK_G1BLKR3    : bit  absolute COG1BLK.7;
+  COG1BLK_G1BLKR2    : bit  absolute COG1BLK.6;
+  COG1BLK_G1BLKR1    : bit  absolute COG1BLK.5;
+  COG1BLK_G1BLKR0    : bit  absolute COG1BLK.4;
+  COG1BLK_G1BLKF3    : bit  absolute COG1BLK.3;
+  COG1BLK_G1BLKF2    : bit  absolute COG1BLK.2;
+  COG1BLK_G1BLKF1    : bit  absolute COG1BLK.1;
+  COG1BLK_G1BLKF0    : bit  absolute COG1BLK.0;
+  COG1DB             : byte absolute $0194;
+  COG1DB_G1BDR3      : bit  absolute COG1DB.7;
+  COG1DB_G1BDR2      : bit  absolute COG1DB.6;
+  COG1DB_G1BDR1      : bit  absolute COG1DB.5;
+  COG1DB_G1BDR0      : bit  absolute COG1DB.4;
+  COG1DB_G1DBF3      : bit  absolute COG1DB.3;
+  COG1DB_G1DBF2      : bit  absolute COG1DB.2;
+  COG1DB_G1DBF1      : bit  absolute COG1DB.1;
+  COG1DB_G1DBF0      : bit  absolute COG1DB.0;
+  COG1CON0           : byte absolute $0195;
+  COG1CON0_G1EN      : bit  absolute COG1CON0.7;
+  COG1CON0_G1OE1     : bit  absolute COG1CON0.6;
+  COG1CON0_G1OE0     : bit  absolute COG1CON0.5;
+  COG1CON0_G1POL1    : bit  absolute COG1CON0.4;
+  COG1CON0_G1POL0    : bit  absolute COG1CON0.3;
+  COG1CON0_G1LD      : bit  absolute COG1CON0.2;
+  COG1CON0_G1CS0     : bit  absolute COG1CON0.1;
+  COG1CON1           : byte absolute $0196;
+  COG1CON1_G1FSIM    : bit  absolute COG1CON1.7;
+  COG1CON1_G1RSIM    : bit  absolute COG1CON1.6;
+  COG1CON1_G1FS2     : bit  absolute COG1CON1.5;
+  COG1CON1_G1FS1     : bit  absolute COG1CON1.4;
+  COG1CON1_G1FS0     : bit  absolute COG1CON1.3;
+  COG1CON1_G1RS2     : bit  absolute COG1CON1.2;
+  COG1CON1_G1RS1     : bit  absolute COG1CON1.1;
+  COG1CON1_G1RS0     : bit  absolute COG1CON1.0;
+  COG1ASD            : byte absolute $0197;
+  COG1ASD_G1ASDE     : bit  absolute COG1ASD.7;
+  COG1ASD_G1ARSEN    : bit  absolute COG1ASD.6;
+  COG1ASD_G1ASDL1    : bit  absolute COG1ASD.5;
+  COG1ASD_G1ASDL0    : bit  absolute COG1ASD.4;
+  COG1ASD_G1ASDSHLT  : bit  absolute COG1ASD.3;
+  COG1ASD_G1ASDSC2   : bit  absolute COG1ASD.2;
+  COG1ASD_G1ASDSC1   : bit  absolute COG1ASD.1;
+  COG1ASD_G1ASDSFLT  : bit  absolute COG1ASD.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '008-008:SFR'}  // IOCAF
+  {$SET_STATE_RAM '00A-00D:SFR'}  // PCLATH, INTCON, PIR1, PIR2
+  {$SET_STATE_RAM '00F-015:SFR'}  // TMR1L, TMR1H, T1CON, T1GCON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '01C-01F:SFR'}  // ADRESL, ADRESH, ADCON0, ADCON1
+  {$SET_STATE_RAM '040-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '088-088:SFR'}  // IOCAP
+  {$SET_STATE_RAM '08A-08D:SFR'}  // PCLATH, INTCON, PIE1, PIE2
+  {$SET_STATE_RAM '08F-092:SFR'}  // OSCCON, FVRCON, DACCON0, DACCON1
+  {$SET_STATE_RAM '09B-09F:SFR'}  // CM2CON0, CM2CON1, CM1CON0, CM1CON1, CMOUT
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-105:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, LATA
+  {$SET_STATE_RAM '108-108:SFR'}  // IOCAN
+  {$SET_STATE_RAM '10A-10D:SFR'}  // PCLATH, INTCON, WPUA, SLRCONA
+  {$SET_STATE_RAM '10F-116:SFR'}  // PCON, TMR2, PR2, T2CON, HLTMR1, HLTPR1, HLT1CON0, HLT1CON1
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-185:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA
+  {$SET_STATE_RAM '188-197:SFR'}  // APFCON, OSCTUNE, PCLATH, INTCON, PMCON1, PMCON2, PMADRL, PMADRH, PMDATL, PMDATH, COG1PH, COG1BLK, COG1DB, COG1CON0, COG1CON1, COG1ASD
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '008:3F'} // IOCAF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:C7'} // PIR1
+  {$SET_UNIMP_BITS '00D:35'} // PIR2
+  {$SET_UNIMP_BITS '011:F0'} // T1CON
+  {$SET_UNIMP_BITS '012:03'} // T1GCON
+  {$SET_UNIMP_BITS '015:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:70'} // ADCON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '088:3F'} // IOCAP
+  {$SET_UNIMP_BITS '08C:C7'} // PIE1
+  {$SET_UNIMP_BITS '08D:35'} // PIE2
+  {$SET_UNIMP_BITS '08F:36'} // OSCCON
+  {$SET_UNIMP_BITS '090:F0'} // FVRCON
+  {$SET_UNIMP_BITS '091:E4'} // DACCON0
+  {$SET_UNIMP_BITS '092:1F'} // DACCON1
+  {$SET_UNIMP_BITS '09C:F1'} // CM2CON1
+  {$SET_UNIMP_BITS '09E:F1'} // CM1CON1
+  {$SET_UNIMP_BITS '09F:03'} // CMOUT
+  {$SET_UNIMP_BITS '105:37'} // LATA
+  {$SET_UNIMP_BITS '108:3F'} // IOCAN
+  {$SET_UNIMP_BITS '10C:3F'} // WPUA
+  {$SET_UNIMP_BITS '10D:05'} // SLRCONA
+  {$SET_UNIMP_BITS '10F:03'} // PCON
+  {$SET_UNIMP_BITS '111:00'} // PR2
+  {$SET_UNIMP_BITS '112:7B'} // T2CON
+  {$SET_UNIMP_BITS '114:00'} // HLTPR1
+  {$SET_UNIMP_BITS '115:7B'} // HLT1CON0
+  {$SET_UNIMP_BITS '116:1F'} // HLT1CON1
+  {$SET_UNIMP_BITS '185:37'} // ANSELA
+  {$SET_UNIMP_BITS '188:17'} // APFCON
+  {$SET_UNIMP_BITS '189:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '18C:07'} // PMCON1
+  {$SET_UNIMP_BITS '18F:03'} // PMADRH
+  {$SET_UNIMP_BITS '191:3F'} // PMDATH
+  {$SET_UNIMP_BITS '192:0F'} // COG1PH
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : COG1OUT0/IOC/CLKIN/T1CKI/C2IN1-/RA5
+  // Pin  3 : C1IN1-/CLKOUT/COG1OUT1/COG1FLT/IOC/T1G/AN3/RA4
+  // Pin  4 : MCLR/Vpp/COG1FLT/T1G/IOC/RA3
+  // Pin  5 : COG1OUT0/INT/IOC/CCP1/T0CKI/C2OUT/C1OUT/AN2/RA2
+  // Pin  6 : ICSPCLK/VREF+/IOC/C2IN0-/C1IN0-/AN1/RA1
+  // Pin  7 : ICSPDAT/REFOUT/DACOUT/COG1OUT1/IOC/C2IN0+/C1IN0+/AN0/RA0
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-7,1-6,2-5,3-4,4-3,5-2'} // PORTA
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : Debug Mode Enable bit
+  {$define _DEBUG_OFF       = $3F79}  // Debug mode disabled
+  {$define _DEBUG_ON        = $3F78}  // Debug mode enabled
+
+  // CLKOUTEN : Clock Out Enable bit
+  {$define _CLKOUTEN_OFF    = $3F7B}  // CLKOUT function disabled.  CLKOUT pin acts as I/O
+  {$define _CLKOUTEN_ON     = $3F79}  // CLKOUT function enabled.  CLKOUT pin is CLKOUT
+
+  // WRT : Flash Program Memory Self Write Enable bit
+  {$define _WRT_OFF         = $3F7D}  // Flash self-write protection off
+  {$define _WRT_FOURTH      = $3F79}  // 000h to 0FFh self-write protected
+  {$define _WRT_HALF        = $3F75}  // 000h to 1FFh self-write protected
+  {$define _WRT_ALL         = $3F71}  // 000h to 3FFh self-write protected
+
+  // BOREN : Brown-out Reset Enable bits
+  {$define _BOREN_EN        = $3F79}  // BOR enabled
+  {$define _BOREN_SLEEP_DIS = $3F69}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_DIS       = $3F49}  // BOR disabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF          = $3F79}  // Program memory code protection is disabled
+  {$define _CP_ON           = $3F39}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON        = $3FF9}  // MCLR pin is MCLR function with internal weak pullup
+  {$define _MCLRE_OFF       = $3F79}  // MCLR pin is alternate function
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF       = $3F79}  // Power-up Timer disabled
+  {$define _PWRTE_ON        = $3E79}  // Power-up Timer enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON         = $3F79}  // Watchdog Timer enabled
+  {$define _WDTE_OFF        = $3D79}  // Watchdog Timer disabled
+
+  // FOSC0 : FOSC: Oscillator Selection bit
+  {$define _FOSC0_EC        = $3F79}  // EC oscillator mode.  CLKIN function on RA5/CLKIN
+  {$define _FOSC0_INT       = $3B79}  // Internal oscillator mode.  I/O function on RA5/CLKIN
+
+implementation
+end.

--- a/PIC16F610.pas
+++ b/PIC16F610.pas
@@ -1,0 +1,277 @@
+unit PIC16F610;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F610'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_C2IF         : bit  absolute PIR1.3;
+  PIR1_C1IF         : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  VRCON             : byte absolute $0019;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $001a;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $001b;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $001c;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1ACS     : bit  absolute CM2CON1.5;
+  CM2CON1_C1HYS     : bit  absolute CM2CON1.4;
+  CM2CON1_C2HYS     : bit  absolute CM2CON1.3;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.2;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_C2IE         : bit  absolute PIE1.3;
+  PIE1_C1IE         : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS1        : bit  absolute ANSEL.3;
+  ANSEL_ANS0        : bit  absolute ANSEL.2;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  SRCON0            : byte absolute $0099;
+  SRCON0_SR1        : bit  absolute SRCON0.7;
+  SRCON0_SR0        : bit  absolute SRCON0.6;
+  SRCON0_C1SEN      : bit  absolute SRCON0.5;
+  SRCON0_C2REN      : bit  absolute SRCON0.4;
+  SRCON0_PULSS      : bit  absolute SRCON0.3;
+  SRCON0_PULSR      : bit  absolute SRCON0.2;
+  SRCON0_SRCLKEN    : bit  absolute SRCON0.1;
+  SRCON1            : byte absolute $009a;
+  SRCON1_SRCS1      : bit  absolute SRCON1.7;
+  SRCON1_SRCS0      : bit  absolute SRCON1.6;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '019-01C:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '040-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-091:SFR'}  // OSCTUNE, ANSEL
+  {$SET_STATE_RAM '095-096:SFR'}  // WPUA, IOCA
+  {$SET_STATE_RAM '099-09A:SFR'}  // SRCON0, SRCON1
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:19'} // PIR1
+  {$SET_UNIMP_BITS '01A:F7'} // CM1CON0
+  {$SET_UNIMP_BITS '01B:F7'} // CM2CON0
+  {$SET_UNIMP_BITS '01C:DF'} // CM2CON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08C:19'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '091:F3'} // ANSEL
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '099:FD'} // SRCON0
+  {$SET_UNIMP_BITS '09A:C0'} // SRCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/AN7/C12IN3-
+  // Pin  8 : RC2/AN6/C12IN2-
+  // Pin  9 : RC1/AN5/C12IN1-
+  // Pin 10 : RC0/AN4/C2IN+
+  // Pin 11 : RA2/T0CKI/INT/C1OUT
+  // Pin 12 : RA1/AN1/C12IN0-/ICSPCLK
+  // Pin 13 : RA0/AN0/C1IN+/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $03FF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $03FE}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $03FD}  // BOR Disabled
+  {$define _BOREN_OFF      = $03FC}  // BOR Disabled
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_8MHZ    = $03FF}  // 8 MHz
+  {$define _IOSCFS_4MHZ    = $03FB}  // 4 MHz
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $03FF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $03F7}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $03FF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $03EF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $03FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $03DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $03FF}  // WDT enabled
+  {$define _WDTE_OFF       = $03BF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $03FF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $037F}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $02FF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $027F}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC        = $01FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS        = $017F}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT        = $00FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP        = $007F}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F616.pas
+++ b/PIC16F616.pas
@@ -1,0 +1,342 @@
+unit PIC16F616;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F616'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_ECCPIF       : bit  absolute PIR1.5;
+  PIR1_C2IF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0013;
+  CCPR1H            : byte absolute $0014;
+  CCP1CON           : byte absolute $0015;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  PWM1CON           : byte absolute $0016;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $0017;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  VRCON             : byte absolute $0019;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $001a;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $001b;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $001c;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1ACS     : bit  absolute CM2CON1.5;
+  CM2CON1_C1HYS     : bit  absolute CM2CON1.4;
+  CM2CON1_C2HYS     : bit  absolute CM2CON1.3;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.2;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.1;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_ECCPIE       : bit  absolute PIE1.5;
+  PIE1_C2IE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  SRCON0            : byte absolute $0099;
+  SRCON0_SR1        : bit  absolute SRCON0.7;
+  SRCON0_SR0        : bit  absolute SRCON0.6;
+  SRCON0_C1SEN      : bit  absolute SRCON0.5;
+  SRCON0_C2REN      : bit  absolute SRCON0.4;
+  SRCON0_PULSS      : bit  absolute SRCON0.3;
+  SRCON0_PULSR      : bit  absolute SRCON0.2;
+  SRCON0_SRCLKEN    : bit  absolute SRCON0.1;
+  SRCON1            : byte absolute $009a;
+  SRCON1_SRCS1      : bit  absolute SRCON1.7;
+  SRCON1_SRCS0      : bit  absolute SRCON1.6;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-017:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, CCPR1L, CCPR1H, CCP1CON, PWM1CON, ECCPAS
+  {$SET_STATE_RAM '019-01C:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-092:SFR'}  // OSCTUNE, ANSEL, PR2
+  {$SET_STATE_RAM '095-096:SFR'}  // WPUA, IOCA
+  {$SET_STATE_RAM '099-09A:SFR'}  // SRCON0, SRCON1
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7B'} // PIR1
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01A:F7'} // CM1CON0
+  {$SET_UNIMP_BITS '01B:F7'} // CM2CON0
+  {$SET_UNIMP_BITS '01C:DF'} // CM2CON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08C:7B'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '099:FD'} // SRCON0
+  {$SET_UNIMP_BITS '09A:C0'} // SRCON1
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/CCP1/P1A
+  // Pin  6 : RC4/C2OUT/P1B
+  // Pin  7 : RC3/AN7/C12IN3-/P1C
+  // Pin  8 : RC2/AN6/C12IN2-/P1D
+  // Pin  9 : RC1/AN5/C12IN1-
+  // Pin 10 : RC0/AN4/C2IN+
+  // Pin 11 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 12 : RA1/AN1/C12IN0-/Vref/ICSPCK
+  // Pin 13 : RA0/AN0/C1IN+/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $03FF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $03FE}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $03FD}  // BOR Disabled
+  {$define _BOREN_OFF      = $03FC}  // BOR Disabled
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_8MHZ    = $03FF}  // 8 MHz
+  {$define _IOSCFS_4MHZ    = $03FB}  // 4 MHz
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $03FF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $03F7}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $03FF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $03EF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $03FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $03DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $03FF}  // WDT enabled
+  {$define _WDTE_OFF       = $03BF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $03FF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $037F}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $02FF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $027F}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC        = $01FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS        = $017F}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT        = $00FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP        = $007F}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F627.pas
+++ b/PIC16F627.pas
@@ -1,0 +1,302 @@
+unit PIC16F627;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F627'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_CMIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CMCON             : byte absolute $001f;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_CMIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_OSCF         : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  VRCON             : byte absolute $009f;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-012:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01F-01F:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-09D:SFR'}  // TXSTA, SPBRG, EEDATA, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '09F-09F:SFR'}  // VRCON
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '120-14F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:F7'} // PIR1
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '08C:F7'} // PIE1
+  {$SET_UNIMP_BITS '08E:0B'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:EF'} // VRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref
+  // Pin  2 : RA3/AN3/CMP1
+  // Pin  3 : RA4/T0CKI/CMP2
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/RX/DT
+  // Pin  8 : RB2/TX/CK
+  // Pin  9 : RB3/CCP1
+  // Pin 10 : RB4/PGM
+  // Pin 11 : RB5
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKOUT
+  // Pin 16 : RA7/OSC1/CLKIN
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Code Protection bits
+  {$define _CP_OFF         = $3DFF}  // Program memory code protection off
+  {$define _CP_50          = $3DFA}  // Program memory code protection off
+  {$define _CP_75          = $3DF5}  // 0200h-03FFh code protected
+  {$define _CP_ALL         = $3DF0}  // 0000h-03FFh code protected
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $3DFF}  // Data memory code protection off
+  {$define _CPD_ON         = $3DEF}  // Data memory code protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $3DFF}  // RB4/PGM pin has PGM function, low-voltage programming enabled
+  {$define _LVP_OFF        = $3DDF}  // RB4/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $3DFF}  // BOD Reset enabled
+  {$define _BOREN_OFF      = $3DBF}  // BOD Reset disabled
+
+  // MCLRE : RA5/MCLR pin function select
+  {$define _MCLRE_ON       = $3DFF}  // RA5/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $3D7F}  // RA5/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3DFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $3CFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $3DFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_ERCLK     = $4DFF}  // ER oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, Resistor on RA7/OSC1/CLKIN
+  {$define _FOSC_ERIO      = $49FF}  // ER oscillator: I/O function on RA6/OSC2/CLKOUT pin, Resistor on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $45FF}  // INTRC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $41FF}  // INTRC oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_ECIO      = $0DFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $09FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $05FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F627A.pas
+++ b/PIC16F627A.pas
@@ -1,0 +1,300 @@
+unit PIC16F627A;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F627A'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_CMIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CMCON             : byte absolute $001f;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_CMIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_OSCF         : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  VRCON             : byte absolute $009f;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-012:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01F-01F:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-09D:SFR'}  // TXSTA, SPBRG, EEDATA, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '09F-09F:SFR'}  // VRCON
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '120-14F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:F7'} // PIR1
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '08C:F7'} // PIE1
+  {$SET_UNIMP_BITS '08E:0B'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:EF'} // VRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref
+  // Pin  2 : RA3/AN3/CMP1
+  // Pin  3 : RA4/T0CKI/CMP2
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/RX/DT
+  // Pin  8 : RB2/TX/CK
+  // Pin  9 : RB3/CCP1
+  // Pin 10 : RB4/PGM
+  // Pin 11 : RB5
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKOUT
+  // Pin 16 : RA7/OSC1/CLKIN
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $21FF}  // Code protection off
+  {$define _CP_ON          = $21FE}  // 0000h to 03FFh code-protected
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $21FF}  // Data memory code protection off
+  {$define _CPD_ON         = $21FD}  // Data memory code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $21FF}  // RB4/PGM pin has PGM function, low-voltage programming enabled
+  {$define _LVP_OFF        = $21FB}  // RB4/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON       = $21FF}  // BOD enabled
+  {$define _BOREN_OFF      = $21F7}  // BOD disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $21FF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $21EF}  // RA5/MCLR/VPP pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $21FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $21DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $21FF}  // WDT enabled
+  {$define _WDTE_OFF       = $21BF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $29FF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, Resistor and Capacitor on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $297F}  // RC oscillator: I/O function on RA6/OSC2/CLKOUT pin, Resistor and Capacitor on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $28FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $287F}  // INTOSC oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_ECIO      = $21FF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $217F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $20FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $207F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F628.pas
+++ b/PIC16F628.pas
@@ -1,0 +1,302 @@
+unit PIC16F628;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F628'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_CMIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CMCON             : byte absolute $001f;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_CMIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_OSCF         : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  VRCON             : byte absolute $009f;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-012:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01F-01F:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-09D:SFR'}  // TXSTA, SPBRG, EEDATA, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '09F-09F:SFR'}  // VRCON
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '120-14F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:F7'} // PIR1
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '08C:F7'} // PIE1
+  {$SET_UNIMP_BITS '08E:0B'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:EF'} // VRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref
+  // Pin  2 : RA3/AN3/CMP1
+  // Pin  3 : RA4/T0CKI/CMP2
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/RX/DT
+  // Pin  8 : RB2/TX/CK
+  // Pin  9 : RB3/CCP1
+  // Pin 10 : RB4/PGM
+  // Pin 11 : RB5
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKOUT
+  // Pin 16 : RA7/OSC1/CLKIN
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Code Protection bits
+  {$define _CP_OFF         = $3DFF}  // Program memory code protection off
+  {$define _CP_50          = $3DFA}  // 0400h-07FFh code protected
+  {$define _CP_75          = $3DF5}  // 0200h-07FFh code protected
+  {$define _CP_ALL         = $3DF0}  // 0000h-07FFh code protected
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $3DFF}  // Data memory code protection off
+  {$define _CPD_ON         = $3DEF}  // Data memory code protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $3DFF}  // RB4/PGM pin has PGM function, low-voltage programming enabled
+  {$define _LVP_OFF        = $3DDF}  // RB4/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $3DFF}  // BOD Reset enabled
+  {$define _BOREN_OFF      = $3DBF}  // BOD Reset disabled
+
+  // MCLRE : RA5/MCLR pin function select
+  {$define _MCLRE_ON       = $3DFF}  // RA5/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $3D7F}  // RA5/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3DFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $3CFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $3DFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_ERCLK     = $4DFF}  // ER oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, Resistor on RA7/OSC1/CLKIN
+  {$define _FOSC_ERIO      = $49FF}  // ER oscillator: I/O function on RA6/OSC2/CLKOUT pin, Resistor on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $45FF}  // INTRC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $41FF}  // INTRC oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_ECIO      = $0DFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $09FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $05FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F628A.pas
+++ b/PIC16F628A.pas
@@ -1,0 +1,300 @@
+unit PIC16F628A;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F628A'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_CMIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CMCON             : byte absolute $001f;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_CMIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_OSCF         : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  VRCON             : byte absolute $009f;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-012:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01F-01F:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-09D:SFR'}  // TXSTA, SPBRG, EEDATA, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '09F-09F:SFR'}  // VRCON
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '120-14F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:F7'} // PIR1
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '08C:F7'} // PIE1
+  {$SET_UNIMP_BITS '08E:0B'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:EF'} // VRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref
+  // Pin  2 : RA3/AN3/CMP1
+  // Pin  3 : RA4/T0CKI/CMP2
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/RX/DT
+  // Pin  8 : RB2/TX/CK
+  // Pin  9 : RB3/CCP1
+  // Pin 10 : RB4/PGM
+  // Pin 11 : RB5
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKOUT
+  // Pin 16 : RA7/OSC1/CLKIN
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $21FF}  // Code protection off
+  {$define _CP_ON          = $21FE}  // 0000h to 07FFh code-protected
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $21FF}  // Data memory code protection off
+  {$define _CPD_ON         = $21FD}  // Data memory code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $21FF}  // RB4/PGM pin has PGM function, low-voltage programming enabled
+  {$define _LVP_OFF        = $21FB}  // RB4/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON       = $21FF}  // BOD enabled
+  {$define _BOREN_OFF      = $21F7}  // BOD disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $21FF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $21EF}  // RA5/MCLR/VPP pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $21FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $21DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $21FF}  // WDT enabled
+  {$define _WDTE_OFF       = $21BF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $29FF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, Resistor and Capacitor on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $297F}  // RC oscillator: I/O function on RA6/OSC2/CLKOUT pin, Resistor and Capacitor on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $28FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $287F}  // INTOSC oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_ECIO      = $21FF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $217F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $20FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $207F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F630.pas
+++ b/PIC16F630.pas
@@ -1,0 +1,248 @@
+unit PIC16F630;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F630'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.4;
+  PIR1_CMIF         : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  CMCON             : byte absolute $0019;
+  CMCON_COUT        : bit  absolute CMCON.6;
+  CMCON_CINV        : bit  absolute CMCON.5;
+  CMCON_CIS         : bit  absolute CMCON.4;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.4;
+  PIE1_CMIE         : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCAL            : byte absolute $0090;
+  OSCCAL_CAL5       : bit  absolute OSCCAL.7;
+  OSCCAL_CAL4       : bit  absolute OSCCAL.6;
+  OSCCAL_CAL3       : bit  absolute OSCCAL.5;
+  OSCCAL_CAL2       : bit  absolute OSCCAL.4;
+  OSCCAL_CAL1       : bit  absolute OSCCAL.3;
+  OSCCAL_CAL0       : bit  absolute OSCCAL.2;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '019-019:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-05F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-090:SFR'}  // OSCCAL
+  {$SET_STATE_RAM '095-096:SFR'}  // WPUA, IOCA
+  {$SET_STATE_RAM '099-09D:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '0A0-0DF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:89'} // PIR1
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '019:5F'} // CMCON
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08C:89'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:FC'} // OSCCAL
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09B:7F'} // EEADR
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4
+  // Pin  7 : RC3
+  // Pin  8 : RC2
+  // Pin  9 : RC1
+  // Pin 10 : RC0
+  // Pin 11 : RA2/COUT/T0CKI/INT
+  // Pin 12 : RA1/CIN-/ICSPCLK
+  // Pin 13 : RA0/CIN+/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // BG : Bandgap Calibration bits for BOD and POR voltage
+  {$define _BG_3          = $31FF}  // Highest bandgap voltage
+  {$define _BG_2          = $31FE}  // .
+  {$define _BG_1          = $31FD}  // .
+  {$define _BG_0          = $31FC}  // Lowest bandgap voltage
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $31FF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $31FB}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $31FF}  // Program Memory code protection is disabled
+  {$define _CP_ON         = $31F7}  // Program Memory code protection is enabled
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON      = $31FF}  // BOD enabled
+  {$define _BOREN_OFF     = $31EF}  // BOD disabled
+
+  // MCLRE : RA3/MCLR pin function select
+  {$define _MCLRE_ON      = $31FF}  // RA3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $31DF}  // RA3/MCLR pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $31FF}  // PWRT disabled
+  {$define _PWRTE_ON      = $31BF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $31FF}  // WDT enabled
+  {$define _WDTE_OFF      = $317F}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $37FF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $36FF}  // RC oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $35FF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $34FF}  // INTOSC oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $33FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $32FF}  // HS oscillator: High speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $31FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $30FF}  // LP oscillator: Low power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F631.pas
+++ b/PIC16F631.pas
@@ -1,0 +1,353 @@
+unit PIC16F631;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F631'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDTCON            : byte absolute $0097;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  EEDAT             : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  VRCON             : byte absolute $0118;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  ANSEL             : byte absolute $011e;
+  ANSEL_ANS7        : bit  absolute ANSEL.6;
+  ANSEL_ANS6        : bit  absolute ANSEL.5;
+  ANSEL_ANS5        : bit  absolute ANSEL.4;
+  ANSEL_ANS4        : bit  absolute ANSEL.3;
+  ANSEL_ANS1        : bit  absolute ANSEL.2;
+  ANSEL_ANS0        : bit  absolute ANSEL.1;
+  EECON1            : byte absolute $018c;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  SRCON             : byte absolute $019e;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-010:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '040-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '095-097:SFR'}  // WPUA, IOCA, WDTCON
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10D:SFR'}  // PCLATH, INTCON, EEDAT, EEADR
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '118-11B:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '11E-11E:SFR'}  // ANSEL
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '19E-19E:SFR'}  // SRCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:01'} // PIR1
+  {$SET_UNIMP_BITS '00D:F0'} // PIR2
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08C:07'} // PIE1
+  {$SET_UNIMP_BITS '08D:F0'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:1F'} // WDTCON
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11E:F3'} // ANSEL
+  {$SET_UNIMP_BITS '18C:0F'} // EECON1
+  {$SET_UNIMP_BITS '19E:FC'} // SRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/AN7/C12IN3-
+  // Pin  8 : RC6
+  // Pin  9 : RC7
+  // Pin 10 : RB7
+  // Pin 11 : RB6
+  // Pin 12 : RB5
+  // Pin 13 : RB4
+  // Pin 14 : RC2/AN6/C12IN2-
+  // Pin 15 : RC1/AN5/C12IN1-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/ICSPCK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON      = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF     = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON       = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF      = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN  = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF     = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON         = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON      = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF      = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $0FFF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $0DFF}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F636.pas
+++ b/PIC16F636.pas
@@ -1,0 +1,328 @@
+unit PIC16F636;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F636'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_LVDIF        : bit  absolute PIR1.6;
+  PIR1_CRIF         : bit  absolute PIR1.5;
+  PIR1_C2IF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_OSFIF        : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CMCON0            : byte absolute $0019;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON1            : byte absolute $001a;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_LVDIE        : bit  absolute PIE1.6;
+  PIE1_CRIE         : bit  absolute PIE1.5;
+  PIE1_C2IE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_OSFIE        : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_WUR          : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  LVDCON            : byte absolute $0094;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  WPUDA             : byte absolute $0095;
+  WPUDA_WPUDA5      : bit  absolute WPUDA.5;
+  WPUDA_WPUDA4      : bit  absolute WPUDA.4;
+  WPUDA_WPUDA2      : bit  absolute WPUDA.3;
+  WPUDA_WPUDA1      : bit  absolute WPUDA.2;
+  WPUDA_WPUDA0      : bit  absolute WPUDA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDA               : byte absolute $0097;
+  WDA_WDA5          : bit  absolute WDA.5;
+  WDA_WDA4          : bit  absolute WDA.4;
+  WDA_WDA2          : bit  absolute WDA.3;
+  WDA_WDA1          : bit  absolute WDA.2;
+  WDA_WDA0          : bit  absolute WDA.1;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  CRCON             : byte absolute $0110;
+  CRCON_GO_nDONE    : bit  absolute CRCON.7;
+  CRCON_ENC_nDEC    : bit  absolute CRCON.6;
+  CRCON_CRREG1      : bit  absolute CRCON.5;
+  CRCON_CRREG0      : bit  absolute CRCON.4;
+  CRDAT0            : byte absolute $0111;
+  CRDAT1            : byte absolute $0112;
+  CRDAT2            : byte absolute $0113;
+  CRDAT3            : byte absolute $0114;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '018-01A:SFR'}  // WDTCON, CMCON0, CMCON1
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-090:SFR'}  // PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '094-097:SFR'}  // LVDCON, WPUDA, IOCA, WDA
+  {$SET_STATE_RAM '099-09D:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-105:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '107-107:SFR'}  // PORTC
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '110-114:SFR'}  // CRCON, CRDAT0, CRDAT1, CRDAT2, CRDAT3
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-185:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '187-187:SFR'}  // TRISC
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-105:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_MAPPED_RAM '107-107:bnk0'} // PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-185:bnk1'} // TRISA
+  {$SET_MAPPED_RAM '187-187:bnk1'} // TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:FD'} // PIR1
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '01A:03'} // CMCON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08C:FD'} // PIE1
+  {$SET_UNIMP_BITS '08E:3B'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '094:37'} // LVDCON
+  {$SET_UNIMP_BITS '095:37'} // WPUDA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:37'} // WDA
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '110:C3'} // CRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3
+  // Pin  8 : RC2
+  // Pin  9 : RC1/C2IN-
+  // Pin 10 : RC0/C2IN+
+  // Pin 11 : RA2/T0CKI/INT/C1OUT
+  // Pin 12 : RA1/C1IN-/Vref/ICSPCLK
+  // Pin 13 : RA0/C1IN+/ICSPDAT/ULPWU
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // WURE : Wake-Up Reset Enable bit
+  {$define _WURE_OFF       = $1FFF}  // Standard wake-up and continue enabled
+  {$define _WURE_ON        = $1FFE}  // Wake-up and Reset enabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor disabled
+
+  // IESO : Internal-External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal External Switchover mode disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOD enabled and SBOdEN bit disabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOD enabled while running and disabled in Sleep. SBODEN bit disabled.
+  {$define _BOREN_SBODEN   = $1FEF}  // SBODEN controls BOD function
+  {$define _BOREN_OFF      = $1FE7}  // BOD and SBODEN disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory is not code protected
+  {$define _CPD_ON         = $1FDF}  // Data memory is external read protected
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory is not code protected
+  {$define _CP_ON          = $1FBF}  // Program memory is external read and write-protected
+
+  // MCLRE : MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // MCLR pin is MCLR function and weak internal pull-up is enabled
+  {$define _MCLRE_OFF      = $1F7F}  // MCLR pin function is alternate function, MCLR function is internally disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA4/T1G/OSC2/CLKOUT pin, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA4/T1G/OSC2/CLKOUT pin, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA4/T1G/OSC2/CLKOUT pin, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA4/T1G/OSC2/CLKOUT pin, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA4/T1G/OSC2/CLKOUT, CLKIN on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+
+implementation
+end.

--- a/PIC16F639.pas
+++ b/PIC16F639.pas
@@ -1,0 +1,334 @@
+unit PIC16F639;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F639'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_LVDIF        : bit  absolute PIR1.6;
+  PIR1_CRIF         : bit  absolute PIR1.5;
+  PIR1_C2IF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_OSFIF        : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CMCON0            : byte absolute $0019;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON1            : byte absolute $001a;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_LVDIE        : bit  absolute PIE1.6;
+  PIE1_CRIE         : bit  absolute PIE1.5;
+  PIE1_C2IE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_OSFIE        : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_WUR          : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  LVDCON            : byte absolute $0094;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  WPUDA             : byte absolute $0095;
+  WPUDA_WPUDA5      : bit  absolute WPUDA.5;
+  WPUDA_WPUDA4      : bit  absolute WPUDA.4;
+  WPUDA_WPUDA2      : bit  absolute WPUDA.3;
+  WPUDA_WPUDA1      : bit  absolute WPUDA.2;
+  WPUDA_WPUDA0      : bit  absolute WPUDA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDA               : byte absolute $0097;
+  WDA_WDA5          : bit  absolute WDA.5;
+  WDA_WDA4          : bit  absolute WDA.4;
+  WDA_WDA2          : bit  absolute WDA.3;
+  WDA_WDA1          : bit  absolute WDA.2;
+  WDA_WDA0          : bit  absolute WDA.1;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  CRCON             : byte absolute $0110;
+  CRCON_GO_nDONE    : bit  absolute CRCON.7;
+  CRCON_ENC_nDEC    : bit  absolute CRCON.6;
+  CRCON_CRREG1      : bit  absolute CRCON.5;
+  CRCON_CRREG0      : bit  absolute CRCON.4;
+  CRDAT0            : byte absolute $0111;
+  CRDAT1            : byte absolute $0112;
+  CRDAT2            : byte absolute $0113;
+  CRDAT3            : byte absolute $0114;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '018-01A:SFR'}  // WDTCON, CMCON0, CMCON1
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-090:SFR'}  // PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '094-097:SFR'}  // LVDCON, WPUDA, IOCA, WDA
+  {$SET_STATE_RAM '099-09D:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-105:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '107-107:SFR'}  // PORTC
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '110-114:SFR'}  // CRCON, CRDAT0, CRDAT1, CRDAT2, CRDAT3
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-185:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '187-187:SFR'}  // TRISC
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-105:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_MAPPED_RAM '107-107:bnk0'} // PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-185:bnk1'} // TRISA
+  {$SET_MAPPED_RAM '187-187:bnk1'} // TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:FD'} // PIR1
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '01A:03'} // CMCON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08C:FD'} // PIE1
+  {$SET_UNIMP_BITS '08E:3B'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '094:37'} // LVDCON
+  {$SET_UNIMP_BITS '095:37'} // WPUDA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:37'} // WDA
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '110:C3'} // CRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/LFDATA/RSSI/CCLK/SDIO
+  // Pin  8 : Vddt
+  // Pin  9 : LCZ
+  // Pin 10 : LCY
+  // Pin 11 : LCX
+  // Pin 12 : LCCOM
+  // Pin 13 : Vsst
+  // Pin 14 : RC2/SCLK/ALERT
+  // Pin 15 : RC1/C2IN-/CS
+  // Pin 16 : RC0/C2IN+
+  // Pin 17 : RA2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/C1IN-/Vref/ICSPCLK
+  // Pin 19 : RA0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // WURE : Wake-Up Reset Enable bit
+  {$define _WURE_OFF       = $1FFF}  // Standard wake-up and continue enabled
+  {$define _WURE_ON        = $1FFE}  // Wake-up and Reset enabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor disabled
+
+  // IESO : Internal-External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal External Switchover mode disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOD enabled and SBOdEN bit disabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOD enabled while running and disabled in Sleep. SBODEN bit disabled.
+  {$define _BOREN_SBODEN   = $1FEF}  // SBODEN controls BOD function
+  {$define _BOREN_OFF      = $1FE7}  // BOD and SBODEN disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory is not code protected
+  {$define _CPD_ON         = $1FDF}  // Data memory is external read protected
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory is not code protected
+  {$define _CP_ON          = $1FBF}  // Program memory is external read and write-protected
+
+  // MCLRE : MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // MCLR pin is MCLR function and weak internal pull-up is enabled
+  {$define _MCLRE_OFF      = $1F7F}  // MCLR pin function is alternate function, MCLR function is internally disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA4/T1G/OSC2/CLKOUT pin, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA4/T1G/OSC2/CLKOUT pin, RC on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA4/T1G/OSC2/CLKOUT pin, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA4/T1G/OSC2/CLKOUT pin, I/O function on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA4/T1G/OSC2/CLKOUT, CLKIN on RA5/T1CKI/OSC1/CLKIN
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA5/T1CKI/OSC1/CLKIN and RA4/T1G/OSC2/CLKOUT
+
+implementation
+end.

--- a/PIC16F648A.pas
+++ b/PIC16F648A.pas
@@ -1,0 +1,299 @@
+unit PIC16F648A;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F648A'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_CMIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CMCON             : byte absolute $001f;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_CMIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PCON              : byte absolute $008e;
+  PCON_OSCF         : bit  absolute PCON.3;
+  PCON_POR          : bit  absolute PCON.2;
+  PCON_BOR          : bit  absolute PCON.1;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  VRCON             : byte absolute $009f;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-012:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01F-01F:SFR'}  // CMCON
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-09D:SFR'}  // TXSTA, SPBRG, EEDATA, EEADR, EECON1, EECON2
+  {$SET_STATE_RAM '09F-09F:SFR'}  // VRCON
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:F7'} // PIR1
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '08C:F7'} // PIE1
+  {$SET_UNIMP_BITS '08E:0B'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:EF'} // VRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref
+  // Pin  2 : RA3/AN3/CMP1
+  // Pin  3 : RA4/T0CKI/CMP2
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/RX/DT
+  // Pin  8 : RB2/TX/CK
+  // Pin  9 : RB3/CCP1
+  // Pin 10 : RB4/PGM
+  // Pin 11 : RB5
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKOUT
+  // Pin 16 : RA7/OSC1/CLKIN
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $21FF}  // Code protection off
+  {$define _CP_ON          = $21FE}  // 0000h to 0FFFh code-protected
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $21FF}  // Data memory code protection off
+  {$define _CPD_ON         = $21FD}  // Data memory code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $21FF}  // RB4/PGM pin has PGM function, low-voltage programming enabled
+  {$define _LVP_OFF        = $21FB}  // RB4/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON       = $21FF}  // BOD enabled
+  {$define _BOREN_OFF      = $21F7}  // BOD disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $21FF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $21EF}  // RA5/MCLR/VPP pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $21FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $21DF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $21FF}  // WDT enabled
+  {$define _WDTE_OFF       = $21BF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $29FF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, Resistor and Capacitor on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $297F}  // RC oscillator: I/O function on RA6/OSC2/CLKOUT pin, Resistor and Capacitor on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $28FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $287F}  // INTOSC oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_ECIO      = $21FF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $217F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $20FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $207F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F676.pas
+++ b/PIC16F676.pas
@@ -1,0 +1,275 @@
+unit PIC16F676;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F676'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.5;
+  PIR1_ADIF         : bit  absolute PIR1.4;
+  PIR1_CMIF         : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  CMCON             : byte absolute $0019;
+  CMCON_COUT        : bit  absolute CMCON.6;
+  CMCON_CINV        : bit  absolute CMCON.5;
+  CMCON_CIS         : bit  absolute CMCON.4;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.5;
+  PIE1_ADIE         : bit  absolute PIE1.4;
+  PIE1_CMIE         : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCAL            : byte absolute $0090;
+  OSCCAL_CAL5       : bit  absolute OSCCAL.7;
+  OSCCAL_CAL4       : bit  absolute OSCCAL.6;
+  OSCCAL_CAL3       : bit  absolute OSCCAL.5;
+  OSCCAL_CAL2       : bit  absolute OSCCAL.4;
+  OSCCAL_CAL1       : bit  absolute OSCCAL.3;
+  OSCCAL_CAL0       : bit  absolute OSCCAL.2;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-010:SFR'}  // TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '019-019:SFR'}  // CMCON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-05F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '090-091:SFR'}  // OSCCAL, ANSEL
+  {$SET_STATE_RAM '095-096:SFR'}  // WPUA, IOCA
+  {$SET_STATE_RAM '099-09F:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0DF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:C9'} // PIR1
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '019:5F'} // CMCON
+  {$SET_UNIMP_BITS '01F:DF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08C:C9'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:FC'} // OSCCAL
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09B:7F'} // EEADR
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/T1G/OSC2/AN3/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4
+  // Pin  7 : RC3/AN7
+  // Pin  8 : RC2/AN6
+  // Pin  9 : RC1/AN5
+  // Pin 10 : RC0/AN4
+  // Pin 11 : RA2/AN2/COUT/T0CKI/INT
+  // Pin 12 : RA1/AN1/CIN-/Vref/ICSPCLK
+  // Pin 13 : RA0/AN0/CIN+/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // BG : Bandgap Calibration bits for BOD and POR voltage
+  {$define _BG_3          = $31FF}  // Highest bandgap voltage
+  {$define _BG_2          = $31FE}  // .
+  {$define _BG_1          = $31FD}  // .
+  {$define _BG_0          = $31FC}  // Lowest bandgap voltage
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $31FF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $31FB}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $31FF}  // Program Memory code protection is disabled
+  {$define _CP_ON         = $31F7}  // Program Memory code protection is enabled
+
+  // BOREN : Brown-out Detect Enable bit
+  {$define _BOREN_ON      = $31FF}  // BOD enabled
+  {$define _BOREN_OFF     = $31EF}  // BOD disabled
+
+  // MCLRE : RA3/MCLR pin function select
+  {$define _MCLRE_ON      = $31FF}  // RA3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $31DF}  // RA3/MCLR pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $31FF}  // PWRT disabled
+  {$define _PWRTE_ON      = $31BF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $31FF}  // WDT enabled
+  {$define _WDTE_OFF      = $317F}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $37FF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $36FF}  // RC oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $35FF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $34FF}  // INTOSC oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $33FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $32FF}  // HS oscillator: High speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $31FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $30FF}  // LP oscillator: Low power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F677.pas
+++ b/PIC16F677.pas
@@ -1,0 +1,414 @@
+unit PIC16F677;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F677'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDTCON            : byte absolute $0097;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  EEDAT             : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  VRCON             : byte absolute $0118;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  ANSEL             : byte absolute $011e;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $011f;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  SRCON             : byte absolute $019e;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-010:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '013-014:SFR'}  // SSPBUF, SSPCON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '093-097:SFR'}  // SSPMSK, SSPSTAT, WPUA, IOCA, WDTCON
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10D:SFR'}  // PCLATH, INTCON, EEDAT, EEADR
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '118-11B:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '11E-11F:SFR'}  // ANSEL, ANSELH
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '19E-19E:SFR'}  // SRCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:49'} // PIR1
+  {$SET_UNIMP_BITS '00D:F0'} // PIR2
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08C:4F'} // PIE1
+  {$SET_UNIMP_BITS '08D:F0'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:1F'} // WDTCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11F:0F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:0F'} // EECON1
+  {$SET_UNIMP_BITS '19E:FC'} // SRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/AN7/C12IN3-
+  // Pin  8 : RC6/AN8/SS
+  // Pin  9 : RC7/AN9/SDO
+  // Pin 10 : RB7
+  // Pin 11 : RB6/SCK/SCL
+  // Pin 12 : RB5/AN11
+  // Pin 13 : RB4/AN10/SDI/SDA
+  // Pin 14 : RC2/AN6/C12IN2-
+  // Pin 15 : RC1/AN5/C12IN1-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/Vref/ICSPCK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON      = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF     = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON       = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF      = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN  = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF     = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON         = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON      = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF      = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $0FFF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $0DFF}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F684.pas
+++ b/PIC16F684.pas
@@ -1,0 +1,347 @@
+unit PIC16F684;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F684'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_CCP1IF       : bit  absolute PIR1.5;
+  PIR1_C2IF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_OSFIF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0013;
+  CCPR1H            : byte absolute $0014;
+  CCP1CON           : byte absolute $0015;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  PWM1CON           : byte absolute $0016;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $0017;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CMCON0            : byte absolute $0019;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  CMCON1            : byte absolute $001a;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_CCP1IE       : bit  absolute PIE1.5;
+  PIE1_C2IE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_OSFIE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-01A:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, CCPR1L, CCPR1H, CCP1CON, PWM1CON, ECCPAS, WDTCON, CMCON0, CMCON1
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-092:SFR'}  // PCON, OSCCON, OSCTUNE, ANSEL, PR2
+  {$SET_STATE_RAM '095-096:SFR'}  // WPUA, IOCA
+  {$SET_STATE_RAM '099-09F:SFR'}  // VRCON, EEDAT, EEADR, EECON1, EECON2, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '01A:03'} // CMCON1
+  {$SET_UNIMP_BITS '01F:DF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : VDD
+  // Pin  2 : VSS
+  // Pin  3 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin  4 : RA1/AN1/C1IN-/VREF/ICSPCLK
+  // Pin  5 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin  6 : RA3/MCLR/VPP
+  // Pin  7 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  8 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  9 : RC0/AN4/C2IN+
+  // Pin 10 : RC1/AN5/C2IN-
+  // Pin 11 : RC2/AN6/P1D
+  // Pin 12 : RC3/AN7/P1C
+  // Pin 13 : RC4/C2OUT/P1B
+  // Pin 14 : RC5/CCP1/P1A
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-3,1-4,2-5,3-6,4-7,5-8'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-9,1-10,2-11,3-12,4-13,5-14'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF       = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown Out Detect
+  {$define _BOREN_ON       = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $0EFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $0FFF}  // EXTRC oscillator: External RC on RA5/OSC1/CLKIN, CLKOUT function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_EXTRCIO   = $0DFF}  // EXTRCIO oscillator: External RC on RA5/OSC1/CLKIN, I/O function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_INTOSCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC        = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS        = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT        = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKINT
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F685.pas
+++ b/PIC16F685.pas
@@ -1,0 +1,437 @@
+unit PIC16F685;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F685'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_CCP1IF       : bit  absolute PIR1.5;
+  PIR1_TMR2IF       : bit  absolute PIR1.4;
+  PIR1_TMR1IF       : bit  absolute PIR1.3;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  PWM1CON           : byte absolute $001c;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $001d;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_CCP1IE       : bit  absolute PIE1.5;
+  PIE1_TMR2IE       : bit  absolute PIE1.4;
+  PIE1_TMR1IE       : bit  absolute PIE1.3;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDTCON            : byte absolute $0097;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  EEDAT             : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  VRCON             : byte absolute $0118;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  ANSEL             : byte absolute $011e;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $011f;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  PSTRCON           : byte absolute $019d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  SRCON             : byte absolute $019e;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-012:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-017:SFR'}  // CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '01C-01F:SFR'}  // PWM1CON, ECCPAS, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '095-097:SFR'}  // WPUA, IOCA, WDTCON
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDAT, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '118-11B:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '11E-11F:SFR'}  // ANSEL, ANSELH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '19D-19E:SFR'}  // PSTRCON, SRCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:47'} // PIR1
+  {$SET_UNIMP_BITS '00D:F0'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08C:47'} // PIE1
+  {$SET_UNIMP_BITS '08D:F0'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:1F'} // WDTCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:0F'} // EEADRH
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11F:0F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+  {$SET_UNIMP_BITS '19D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '19E:FC'} // SRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/CCP1/P1A
+  // Pin  6 : RC4/C2OUT/P1B
+  // Pin  7 : RC3/AN7/C12IN3-/P1C
+  // Pin  8 : RC6/AN8
+  // Pin  9 : RC7/AN9
+  // Pin 10 : RB7
+  // Pin 11 : RB6
+  // Pin 12 : RB5/AN11
+  // Pin 13 : RB4/AN10
+  // Pin 14 : RC2/AN6/C12IN2-/P1D
+  // Pin 15 : RC1/AN5/C12IN1-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/Vref/ICSPCK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON      = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF     = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON       = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF      = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN  = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF     = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON         = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON      = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF      = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $0FFF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $0DFF}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F687.pas
+++ b/PIC16F687.pas
@@ -1,0 +1,465 @@
+unit PIC16F687;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F687'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDTCON            : byte absolute $0097;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  BAUDCTL           : byte absolute $009b;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  EEDAT             : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  VRCON             : byte absolute $0118;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  ANSEL             : byte absolute $011e;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $011f;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  SRCON             : byte absolute $019e;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-010:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '013-014:SFR'}  // SSPBUF, SSPCON
+  {$SET_STATE_RAM '018-01A:SFR'}  // RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '093-09B:SFR'}  // SSPMSK, SSPSTAT, WPUA, IOCA, WDTCON, TXSTA, SPBRG, SPBRGH, BAUDCTL
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10D:SFR'}  // PCLATH, INTCON, EEDAT, EEADR
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '118-11B:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '11E-11F:SFR'}  // ANSEL, ANSELH
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '19E-19E:SFR'}  // SRCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:79'} // PIR1
+  {$SET_UNIMP_BITS '00D:F0'} // PIR2
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:F0'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:1F'} // WDTCON
+  {$SET_UNIMP_BITS '09B:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11F:0F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:0F'} // EECON1
+  {$SET_UNIMP_BITS '19E:FC'} // SRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/AN7/C12IN3-
+  // Pin  8 : RC6/AN8/SS
+  // Pin  9 : RC7/AN9/SDO
+  // Pin 10 : RB7/TX/CK
+  // Pin 11 : RB6/SCK/SCL
+  // Pin 12 : RB5/AN11/RX/DT
+  // Pin 13 : RB4/AN10/SDI/SDA
+  // Pin 14 : RC2/AN6/C12IN2-
+  // Pin 15 : RC1/AN5/C12IN1-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/Vref/ICSPCK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON      = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF     = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON       = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF      = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN  = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF     = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON         = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON      = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF      = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $0FFF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $0DFF}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F688.pas
+++ b/PIC16F688.pas
@@ -1,0 +1,358 @@
+unit PIC16F688;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F688'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_C2IF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_OSFIF        : bit  absolute PIR1.2;
+  PIR1_TXIF         : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  BAUDCTL           : byte absolute $0011;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  SPBRGH            : byte absolute $0012;
+  SPBRG             : byte absolute $0013;
+  RCREG             : byte absolute $0014;
+  TXREG             : byte absolute $0015;
+  TXSTA             : byte absolute $0016;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  RCSTA             : byte absolute $0017;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CMCON0            : byte absolute $0019;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  CMCON1            : byte absolute $001a;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_C2IE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_OSFIE        : bit  absolute PIE1.2;
+  PIE1_TXIE         : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBODEN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  EEDATH            : byte absolute $0097;
+  EEADRH            : byte absolute $0098;
+  VRCON             : byte absolute $0099;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  EEDAT             : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-007:SFR'}  // PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-01A:SFR'}  // TMR1L, TMR1H, T1CON, BAUDCTL, SPBRGH, SPBRG, RCREG, TXREG, TXSTA, RCSTA, WDTCON, CMCON0, CMCON1
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-087:SFR'}  // TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-091:SFR'}  // PCON, OSCCON, OSCTUNE, ANSEL
+  {$SET_STATE_RAM '095-09F:SFR'}  // WPUA, IOCA, EEDATH, EEADRH, VRCON, EEDAT, EEADR, EECON1, EECON2, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-105:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '107-107:SFR'}  // PORTC
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-185:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '187-187:SFR'}  // TRISC
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-105:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_MAPPED_RAM '107-107:bnk0'} // PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-185:bnk1'} // TRISA
+  {$SET_MAPPED_RAM '187-187:bnk1'} // TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '011:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '01A:03'} // CMCON1
+  {$SET_UNIMP_BITS '01F:DF'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:3F'} // EEDATH
+  {$SET_UNIMP_BITS '098:0F'} // EEADRH
+  {$SET_UNIMP_BITS '099:AF'} // VRCON
+  {$SET_UNIMP_BITS '09C:8F'} // EECON1
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/RX/DT
+  // Pin  6 : RC4/C2OUT/TX/CK
+  // Pin  7 : RC3/AN7
+  // Pin  8 : RC2/AN6
+  // Pin  9 : RC1/AN5/C2IN-
+  // Pin 10 : RC0/AN4/C2IN+
+  // Pin 11 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 12 : RA1/AN1/C1IN-/Vref/ICSPCLK
+  // Pin 13 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF       = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown Out Detect
+  {$define _BOREN_ON       = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $0EFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $0FFF}  // EXTRC oscillator: External RC on RA5/OSC1/CLKIN, CLKOUT function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_EXTRCIO   = $0DFF}  // EXTRCIO oscillator: External RC on RA5/OSC1/CLKIN, I/O function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_INTOSCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC        = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS        = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT        = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKINT
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F689.pas
+++ b/PIC16F689.pas
@@ -1,0 +1,469 @@
+unit PIC16F689;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F689'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDTCON            : byte absolute $0097;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  BAUDCTL           : byte absolute $009b;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  EEDAT             : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  VRCON             : byte absolute $0118;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  ANSEL             : byte absolute $011e;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $011f;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  SRCON             : byte absolute $019e;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-010:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON
+  {$SET_STATE_RAM '013-014:SFR'}  // SSPBUF, SSPCON
+  {$SET_STATE_RAM '018-01A:SFR'}  // RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '093-09B:SFR'}  // SSPMSK, SSPSTAT, WPUA, IOCA, WDTCON, TXSTA, SPBRG, SPBRGH, BAUDCTL
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDAT, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '118-11B:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '11E-11F:SFR'}  // ANSEL, ANSELH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '19E-19E:SFR'}  // SRCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:79'} // PIR1
+  {$SET_UNIMP_BITS '00D:F0'} // PIR2
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:F0'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:1F'} // WDTCON
+  {$SET_UNIMP_BITS '09B:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:0F'} // EEADRH
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11F:0F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+  {$SET_UNIMP_BITS '19E:FC'} // SRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/AN7/C12IN3-
+  // Pin  8 : RC6/AN8/SS
+  // Pin  9 : RC7/AN9/SDO
+  // Pin 10 : RB7/TX/CK
+  // Pin 11 : RB6/SCK/SCL
+  // Pin 12 : RB5/AN11/RX/DT
+  // Pin 13 : RB4/AN10/SDI/SDA
+  // Pin 14 : RC2/AN6/C12IN2-
+  // Pin 15 : RC1/AN5/C12IN1-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/Vref/ICSPCK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON      = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF     = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON       = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF      = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN  = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF     = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON         = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON      = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF      = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $0FFF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $0DFF}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F690.pas
+++ b/PIC16F690.pas
@@ -1,0 +1,517 @@
+unit PIC16F690;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F690'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  PWM1CON           : byte absolute $001c;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $001d;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA2        : bit  absolute WPUA.3;
+  WPUA_WPUA1        : bit  absolute WPUA.2;
+  WPUA_WPUA0        : bit  absolute WPUA.1;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  WDTCON            : byte absolute $0097;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  BAUDCTL           : byte absolute $009b;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  EEDAT             : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  VRCON             : byte absolute $0118;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VP6EN       : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  ANSEL             : byte absolute $011e;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $011f;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  PSTRCON           : byte absolute $019d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  SRCON             : byte absolute $019e;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-01A:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01C-01F:SFR'}  // PWM1CON, ECCPAS, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-09B:SFR'}  // PR2, SSPMSK, SSPSTAT, WPUA, IOCA, WDTCON, TXSTA, SPBRG, SPBRGH, BAUDCTL
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDAT, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '118-11B:SFR'}  // VRCON, CM1CON0, CM2CON0, CM2CON1
+  {$SET_STATE_RAM '11E-11F:SFR'}  // ANSEL, ANSELH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '19D-19E:SFR'}  // PSTRCON, SRCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:F0'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:F0'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '095:37'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '097:1F'} // WDTCON
+  {$SET_UNIMP_BITS '09B:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:0F'} // EEADRH
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11F:0F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+  {$SET_UNIMP_BITS '19D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '19E:FC'} // SRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/CCP1/P1A
+  // Pin  6 : RC4/C2OUT/P1B
+  // Pin  7 : RC3/AN7/C12IN3-/P1C
+  // Pin  8 : RC6/AN8/SS
+  // Pin  9 : RC7/AN9/SDO
+  // Pin 10 : RB7/TX/CK
+  // Pin 11 : RB6/SCK/SCL
+  // Pin 12 : RB5/AN11/RX/DT
+  // Pin 13 : RB4/AN10/SDI/SDA
+  // Pin 14 : RC2/AN6/C12IN2-/P1D
+  // Pin 15 : RC1/AN5/C12IN1-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/Vref/ICSPCK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT/ULPWU
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON      = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF     = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON       = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF      = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN  = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF     = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF       = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON        = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON         = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON      = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF      = $0EFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK = $0FFF}  // RC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $0DFF}  // RCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, RC on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTRCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC       = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS       = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT       = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_LP       = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F707.pas
+++ b/PIC16F707.pas
@@ -1,0 +1,583 @@
+unit PIC16F707;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F707'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTD              : byte absolute $0008;
+  PORTD_RD7          : bit  absolute PORTD.7;
+  PORTD_RD6          : bit  absolute PORTD.6;
+  PORTD_RD5          : bit  absolute PORTD.5;
+  PORTD_RD4          : bit  absolute PORTD.4;
+  PORTD_RD3          : bit  absolute PORTD.3;
+  PORTD_RD2          : bit  absolute PORTD.2;
+  PORTD_RD1          : bit  absolute PORTD.1;
+  PORTD_RD0          : bit  absolute PORTD.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PORTE_RE2          : bit  absolute PORTE.2;
+  PORTE_RE1          : bit  absolute PORTE.1;
+  PORTE_RE0          : bit  absolute PORTE.0;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_TMR0IE      : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_TMR0IF      : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_TMR3GIF       : bit  absolute PIR2.7;
+  PIR2_TMR3IF        : bit  absolute PIR2.6;
+  PIR2_TMRBIF        : bit  absolute PIR2.5;
+  PIR2_TMRAIF        : bit  absolute PIR2.4;
+  PIR2_CCP2IF        : bit  absolute PIR2.3;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.7;
+  T1CON_TMRCS1       : bit  absolute T1CON.6;
+  T1CON_TMRCS0       : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_TMR0CS  : bit  absolute OPTION_REG.5;
+  OPTION_REG_TMR0SE  : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.1;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISD              : byte absolute $0088;
+  TRISD_TRISD7       : bit  absolute TRISD.7;
+  TRISD_TRISD6       : bit  absolute TRISD.6;
+  TRISD_TRISD5       : bit  absolute TRISD.5;
+  TRISD_TRISD4       : bit  absolute TRISD.4;
+  TRISD_TRISD3       : bit  absolute TRISD.3;
+  TRISD_TRISD2       : bit  absolute TRISD.2;
+  TRISD_TRISD1       : bit  absolute TRISD.1;
+  TRISD_TRISD0       : bit  absolute TRISD.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.3;
+  TRISE_TRISE2       : bit  absolute TRISE.2;
+  TRISE_TRISE1       : bit  absolute TRISE.1;
+  TRISE_TRISE0       : bit  absolute TRISE.0;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_TMR3GIE       : bit  absolute PIE2.7;
+  PIE2_TMR3IE        : bit  absolute PIE2.6;
+  PIE2_TMRBIE        : bit  absolute PIE2.5;
+  PIE2_TMRAIE        : bit  absolute PIE2.4;
+  PIE2_CCP2IE        : bit  absolute PIE2.3;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS1      : bit  absolute T1GCON.1;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.0;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  T3CON              : byte absolute $0097;
+  T3CON_TMR3CS1      : bit  absolute T3CON.7;
+  T3CON_TMR3CS0      : bit  absolute T3CON.6;
+  T3CON_T3CKPS1      : bit  absolute T3CON.5;
+  T3CON_T3CKPS0      : bit  absolute T3CON.4;
+  T3CON_T3SYNC       : bit  absolute T3CON.2;
+  T3CON_TMR3ON       : bit  absolute T3CON.1;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  TMR3L              : byte absolute $009a;
+  TMR3H              : byte absolute $009b;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.7;
+  FVRCON_FVREN       : bit  absolute FVRCON.6;
+  FVRCON_TSEN        : bit  absolute FVRCON.5;
+  FVRCON_TSRNG       : bit  absolute FVRCON.4;
+  FVRCON_CDAFVR1     : bit  absolute FVRCON.3;
+  FVRCON_CDAFVR0     : bit  absolute FVRCON.2;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.1;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.0;
+  T3GCON             : byte absolute $009e;
+  T3GCON_TMR3GE      : bit  absolute T3GCON.7;
+  T3GCON_T3GPOL      : bit  absolute T3GCON.6;
+  T3GCON_T3GTM       : bit  absolute T3GCON.5;
+  T3GCON_T3GSPM      : bit  absolute T3GCON.4;
+  T3GCON_T3GGO_nDONE : bit  absolute T3GCON.3;
+  T3GCON_T3GVAL      : bit  absolute T3GCON.2;
+  T3GCON_T3GSS1      : bit  absolute T3GCON.1;
+  T3GCON_T3GSS0      : bit  absolute T3GCON.0;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  TACON              : byte absolute $0105;
+  TACON_TMRAON       : bit  absolute TACON.7;
+  TACON_TACS         : bit  absolute TACON.6;
+  TACON_TASE         : bit  absolute TACON.5;
+  TACON_TAPSA        : bit  absolute TACON.4;
+  TACON_TMRAPSA      : bit  absolute TACON.3;
+  TACON_TAPS2        : bit  absolute TACON.2;
+  TACON_TAPS1        : bit  absolute TACON.1;
+  TACON_TAPS0        : bit  absolute TACON.0;
+  CPSBCON0           : byte absolute $0106;
+  CPSBCON0_CPSBON    : bit  absolute CPSBCON0.7;
+  CPSBCON0_CPSBRM    : bit  absolute CPSBCON0.6;
+  CPSBCON0_CPSBOUT   : bit  absolute CPSBCON0.3;
+  CPSBCON0_TBXCS     : bit  absolute CPSBCON0.2;
+  CPSBCON1           : byte absolute $0107;
+  CPSBCON1_CPSBCH3   : bit  absolute CPSBCON1.3;
+  CPSBCON1_CPSBCH2   : bit  absolute CPSBCON1.2;
+  CPSBCON1_CPSBCH1   : bit  absolute CPSBCON1.1;
+  CPSBCON1_CPSBCH0   : bit  absolute CPSBCON1.0;
+  CPSACON0           : byte absolute $0108;
+  CPSACON0_CPSAON    : bit  absolute CPSACON0.7;
+  CPSACON0_CPSARM    : bit  absolute CPSACON0.6;
+  CPSACON0_CPSAOUT   : bit  absolute CPSACON0.3;
+  CPSACON0_TAXCS     : bit  absolute CPSACON0.2;
+  CPSACON1           : byte absolute $0109;
+  CPSACON1_CPSACH3   : bit  absolute CPSACON1.3;
+  CPSACON1_CPSACH2   : bit  absolute CPSACON1.2;
+  CPSACON1_CPSACH1   : bit  absolute CPSACON1.1;
+  CPSACON1_CPSACH0   : bit  absolute CPSACON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  TMRA               : byte absolute $0110;
+  TBCON              : byte absolute $0111;
+  TBCON_TMRBON       : bit  absolute TBCON.7;
+  TBCON_TBCS         : bit  absolute TBCON.6;
+  TBCON_TBSE         : bit  absolute TBCON.5;
+  TBCON_TBPSA        : bit  absolute TBCON.4;
+  TBCON_TMRBPSA      : bit  absolute TBCON.3;
+  TBCON_TBPS2        : bit  absolute TBCON.2;
+  TBCON_TBPS1        : bit  absolute TBCON.1;
+  TBCON_TBPS0        : bit  absolute TBCON.0;
+  TMRB               : byte absolute $0112;
+  DACCON0            : byte absolute $0113;
+  DACCON0_DACEN      : bit  absolute DACCON0.6;
+  DACCON0_DACLPS     : bit  absolute DACCON0.5;
+  DACCON0_DACOE      : bit  absolute DACCON0.4;
+  DACCON0_DACPSS1    : bit  absolute DACCON0.3;
+  DACCON0_DACPSS0    : bit  absolute DACCON0.2;
+  DACCON1            : byte absolute $0114;
+  DACCON1_DACR4      : bit  absolute DACCON1.4;
+  DACCON1_DACR3      : bit  absolute DACCON1.3;
+  DACCON1_DACR2      : bit  absolute DACCON1.2;
+  DACCON1_DACR1      : bit  absolute DACCON1.1;
+  DACCON1_DACR0      : bit  absolute DACCON1.0;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA7       : bit  absolute ANSELA.7;
+  ANSELA_ANSA6       : bit  absolute ANSELA.6;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB7       : bit  absolute ANSELB.7;
+  ANSELB_ANSB6       : bit  absolute ANSELB.6;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  ANSELC             : byte absolute $0187;
+  ANSELC_ANSC7       : bit  absolute ANSELC.6;
+  ANSELC_ANSC6       : bit  absolute ANSELC.5;
+  ANSELC_ANSC5       : bit  absolute ANSELC.4;
+  ANSELC_ANSC2       : bit  absolute ANSELC.3;
+  ANSELC_ANSC1       : bit  absolute ANSELC.2;
+  ANSELC_ANSC0       : bit  absolute ANSELC.1;
+  ANSELD             : byte absolute $0188;
+  ANSELD_ANSD7       : bit  absolute ANSELD.7;
+  ANSELD_ANSD6       : bit  absolute ANSELD.6;
+  ANSELD_ANSD5       : bit  absolute ANSELD.5;
+  ANSELD_ANSD4       : bit  absolute ANSELD.4;
+  ANSELD_ANSD3       : bit  absolute ANSELD.3;
+  ANSELD_ANSD2       : bit  absolute ANSELD.2;
+  ANSELD_ANSD1       : bit  absolute ANSELD.1;
+  ANSELD_ANSD0       : bit  absolute ANSELD.0;
+  ANSELE             : byte absolute $0189;
+  ANSELE_ANSE2       : bit  absolute ANSELE.2;
+  ANSELE_ANSE1       : bit  absolute ANSELE.1;
+  ANSELE_ANSE0       : bit  absolute ANSELE.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-09F:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB, T3CON, TXSTA, SPBRG, TMR3L, TMR3H, APFCON, FVRCON, T3GCON, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-114:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, TACON, CPSBCON0, CPSBCON1, CPSACON0, CPSACON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH, TMRA, TBCON, TMRB, DACCON0, DACCON1
+  {$SET_STATE_RAM '115-17F:GPR'} 
+  {$SET_STATE_RAM '180-18C:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB, ANSELC, ANSELD, ANSELE, PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '097:FD'} // T3CON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '105:00'} // TACON
+  {$SET_UNIMP_BITS '106:00'} // CPSBCON0
+  {$SET_UNIMP_BITS '107:00'} // CPSBCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSACON0
+  {$SET_UNIMP_BITS '109:00'} // CPSACON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '110:00'} // TMRA
+  {$SET_UNIMP_BITS '111:00'} // TBCON
+  {$SET_UNIMP_BITS '112:00'} // TMRB
+  {$SET_UNIMP_BITS '113:00'} // DACCON0
+  {$SET_UNIMP_BITS '114:00'} // DACCON1
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '187:3F'} // ANSELC
+  {$SET_UNIMP_BITS '189:07'} // ANSELE
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/SS/Vcap
+  // Pin  3 : RA1/AN1/CPSA0
+  // Pin  4 : RA2/AN2/CPSA1/DACOUT
+  // Pin  5 : RA3/AN3/Vref/CPSA2
+  // Pin  6 : RA4/CPSA3/T0CKI/TACKI
+  // Pin  7 : RA5/AN4/CPSA4/SS/Vcap
+  // Pin  8 : RE0/AN5/CPSA5
+  // Pin  9 : RE1/AN6/CPSA6
+  // Pin 10 : RE2/AN7/CPSA7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : RA7/CPSB0/OSC1/CLKIN
+  // Pin 14 : RA6/CPSB1/OSC2/CLKOUT/Vcap
+  // Pin 15 : RC0/CPSB2/T1OSO/T1CKI
+  // Pin 16 : RC1/CPSB3/T1OSI/CCP2
+  // Pin 17 : RC2/CPSB4/CCP1/TBCKI
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/CPSB5/T3G
+  // Pin 20 : RD1/CPSB6
+  // Pin 21 : RD2/CPSB7
+  // Pin 22 : RD3/CPSA8
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/CPSA9/SDO
+  // Pin 25 : RC6/CPSA10/TX/CK
+  // Pin 26 : RC7/CPSA11/RX/DT
+  // Pin 27 : RD4/CPSA12
+  // Pin 28 : RD5/CPSA13
+  // Pin 29 : RD6/CPSA14
+  // Pin 30 : RD7/CPSA15
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/AN12/CPSB8/INT
+  // Pin 34 : RB1/AN10/CPSB9
+  // Pin 35 : RB2/AN8/CPSB10
+  // Pin 36 : RB3/AN9/CPSB11/CCP2
+  // Pin 37 : RB4/AN11/CPSB12
+  // Pin 38 : RB5/AN13/CPSB13/T1G/T3CKI
+  // Pin 39 : RB6/CPSB14/ICSPCLK/ICDCLK
+  // Pin 40 : RB7/CPSB15/ICSPDAT/ICDDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF     = $377F}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON      = $377E}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_ON      = $377F}  // INTOSC Frequency is 16 MHz (32x)
+  {$define _PLLEN_OFF     = $377D}  // INTOSC Frequency is 500 kHz
+
+  // BORV : Brown-out Reset Voltage Selection bit
+  {$define _BORV_19       = $377F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25       = $377B}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON      = $377F}  // BOR enabled
+  {$define _BOREN_NSLEEP  = $3777}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF     = $376F}  // BOR disabled (Preconditioned State)
+  {$define _BOREN_OFF     = $3767}  // BOR disabled (Preconditioned State)
+
+  // CP : Code Protection bit
+  {$define _CP_OFF        = $377F}  // Program memory code protection is disabled
+  {$define _CP_ON         = $375F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR Pin Function Select bit
+  {$define _MCLRE_ON      = $377F}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF     = $373F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF     = $37FF}  // PWRT disabled
+  {$define _PWRTE_ON      = $377F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON       = $377F}  // WDT enabled
+  {$define _WDTE_OFF      = $367F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC    = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO  = $3D7F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSC   = $3B7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function  on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO = $397F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN pins
+  {$define _FOSC_EC_OSC   = $377F}  // EC oscillator: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS_OSC   = $357F}  // HS oscillator: High Speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT_OSC   = $337F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKIN and RA7/OSC1/CLKIN
+  {$define _FOSC_LP_OSC   = $317F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_OFF    = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6    = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5    = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0    = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F716.pas
+++ b/PIC16F716.pas
@@ -1,0 +1,245 @@
+unit PIC16F716;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F716'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_CCP1IF       : bit  absolute PIR1.5;
+  PIR1_TMR2IF       : bit  absolute PIR1.4;
+  PIR1_TMR1IF       : bit  absolute PIR1.3;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  PWM1CON           : byte absolute $0018;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $0019;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.5;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.1;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_CCP1IE       : bit  absolute PIE1.5;
+  PIE1_TMR2IE       : bit  absolute PIE1.4;
+  PIE1_TMR1IE       : bit  absolute PIE1.3;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  ADCON1            : byte absolute $009f;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-012:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-019:SFR'}  // CCPR1L, CCPR1H, CCP1CON, PWM1CON, ECCPAS
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-08E:SFR'}  // PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:1F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:47'} // PIR1
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '019:DF'} // ECCPAS
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:1F'} // TRISA
+  {$SET_UNIMP_BITS '08C:47'} // PIE1
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '09F:07'} // ADCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2
+  // Pin  2 : RA3/AN3/Vref
+  // Pin  3 : RA4/T0CKI
+  // Pin  4 : MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT/ECCPAS2
+  // Pin  7 : RB1/T1OSO/T1CKI
+  // Pin  8 : RB2/T1OSI
+  // Pin  9 : RB3/CCP1/P1A
+  // Pin 10 : RB4/ECCPAS0
+  // Pin 11 : RB5/P1B
+  // Pin 12 : RB6/P1C
+  // Pin 13 : RB7/P1D
+  // Pin 14 : Vdd
+  // Pin 15 : OSC2/CLKOUT
+  // Pin 16 : OSC1/CLKIN
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Code Protect
+  {$define _CP_OFF    = $20CF}  // Program memory code protection is disabled
+  {$define _CP_ON     = $20CE}  // Program memory code protection is enabled
+
+  // BODENV : Brown-out Reset Voltage bit
+  {$define _BODENV_40 = $20CF}  // VBOR set to 4.0V
+  {$define _BODENV_25 = $20CD}  // VBOR set to 2.5V
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON  = $20CF}  // BOR enabled
+  {$define _BOREN_OFF = $20CB}  // BOR disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF = $20CF}  // PWRT disabled
+  {$define _PWRTE_ON  = $20C7}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON   = $20DF}  // WDT enabled
+  {$define _WDTE_OFF  = $20CF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_RC   = $20EF}  // RC oscillator
+  {$define _FOSC_HS   = $20CF}  // HS oscillator
+  {$define _FOSC_XT   = $20AF}  // XT oscillator
+  {$define _FOSC_LP   = $208F}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F720.pas
+++ b/PIC16F720.pas
@@ -1,0 +1,425 @@
+unit PIC16F720;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F720'}
+{$SET PIC_MAXFREQ  = 16000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.6;
+  PORTA_RA4         : bit  absolute PORTA.5;
+  PORTA_RA3         : bit  absolute PORTA.4;
+  PORTA_RA2         : bit  absolute PORTA.3;
+  PORTA_RA1         : bit  absolute PORTA.2;
+  PORTA_RA0         : bit  absolute PORTA.1;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.4;
+  PORTB_RB6         : bit  absolute PORTB.3;
+  PORTB_RB5         : bit  absolute PORTB.2;
+  PORTB_RB4         : bit  absolute PORTB.1;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_TMR1GIF      : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_TMR1CS1     : bit  absolute T1CON.6;
+  T1CON_TMR1CS0     : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1CKPS0     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1ON      : bit  absolute T1CON.1;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_DC1       : bit  absolute CCP1CON.7;
+  CCP1CON_B1        : bit  absolute CCP1CON.6;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA2      : bit  absolute TRISA.3;
+  TRISA_TRISA1      : bit  absolute TRISA.2;
+  TRISA_TRISA0      : bit  absolute TRISA.1;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.4;
+  TRISB_TRISB6      : bit  absolute TRISB.3;
+  TRISB_TRISB5      : bit  absolute TRISB.2;
+  TRISB_TRISB4      : bit  absolute TRISB.1;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_TMR1GIE      : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  T1GCON            : byte absolute $008f;
+  T1GCON_TMR1GE     : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL     : bit  absolute T1GCON.6;
+  T1GCON_T1GTM      : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM     : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_DONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL     : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0     : bit  absolute T1GCON.1;
+  OSCCON            : byte absolute $0090;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_ICSL       : bit  absolute OSCCON.3;
+  OSCCON_ICSS       : bit  absolute OSCCON.2;
+  OSCTUNE           : byte absolute $0091;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPADD_ADD7       : bit  absolute SSPADD.7;
+  SSPADD_ADD6       : bit  absolute SSPADD.6;
+  SSPADD_ADD5       : bit  absolute SSPADD.5;
+  SSPADD_ADD4       : bit  absolute SSPADD.4;
+  SSPADD_ADD3       : bit  absolute SSPADD.3;
+  SSPADD_ADD2       : bit  absolute SSPADD.2;
+  SSPADD_ADD1       : bit  absolute SSPADD.1;
+  SSPADD_ADD0       : bit  absolute SSPADD.0;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.7;
+  WPUA_WPUA4        : bit  absolute WPUA.6;
+  WPUA_WPUA3        : bit  absolute WPUA.5;
+  WPUA_WPUA2        : bit  absolute WPUA.4;
+  WPUA_WPUA1        : bit  absolute WPUA.3;
+  WPUA_WPUA0        : bit  absolute WPUA.2;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.7;
+  IOCA_IOCA4        : bit  absolute IOCA.6;
+  IOCA_IOCA3        : bit  absolute IOCA.5;
+  IOCA_IOCA2        : bit  absolute IOCA.4;
+  IOCA_IOCA1        : bit  absolute IOCA.3;
+  IOCA_IOCA0        : bit  absolute IOCA.2;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  FVRCON            : byte absolute $009d;
+  FVRCON_FVRRDY     : bit  absolute FVRCON.7;
+  FVRCON_FVREN      : bit  absolute FVRCON.6;
+  FVRCON_TSEN       : bit  absolute FVRCON.5;
+  FVRCON_TSRNG      : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1     : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0     : bit  absolute FVRCON.2;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.4;
+  ADCON1_ADCS1      : bit  absolute ADCON1.3;
+  ADCON1_ADCS0      : bit  absolute ADCON1.2;
+  PMDATL            : byte absolute $010c;
+  PMADRL            : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  ANSELA            : byte absolute $0185;
+  ANSELA_ANSA5      : bit  absolute ANSELA.5;
+  ANSELA_ANSA4      : bit  absolute ANSELA.4;
+  ANSELA_ANSA2      : bit  absolute ANSELA.3;
+  ANSELA_ANSA1      : bit  absolute ANSELA.2;
+  ANSELA_ANSA0      : bit  absolute ANSELA.1;
+  ANSELB            : byte absolute $0186;
+  ANSELB_ANSB5      : bit  absolute ANSELB.5;
+  ANSELB_ANSB4      : bit  absolute ANSELB.4;
+  ANSELC            : byte absolute $0187;
+  ANSELC_ANSC7      : bit  absolute ANSELC.7;
+  ANSELC_ANSC6      : bit  absolute ANSELC.6;
+  ANSELC_ANSC3      : bit  absolute ANSELC.5;
+  ANSELC_ANSC2      : bit  absolute ANSELC.4;
+  ANSELC_ANSC1      : bit  absolute ANSELC.3;
+  ANSELC_ANSC0      : bit  absolute ANSELC.2;
+  PMCON1            : byte absolute $018c;
+  PMCON1_CFGS       : bit  absolute PMCON1.6;
+  PMCON1_LWLO       : bit  absolute PMCON1.5;
+  PMCON1_FREE       : bit  absolute PMCON1.4;
+  PMCON1_WREN       : bit  absolute PMCON1.3;
+  PMCON1_WR         : bit  absolute PMCON1.2;
+  PMCON1_RD         : bit  absolute PMCON1.1;
+  PMCON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-01A:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-096:SFR'}  // PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUA, IOCA
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09D-09D:SFR'}  // FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB, ANSELC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, PMCON1, PMCON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:07'} // PMADRH
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '187:00'} // ANSELC
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+  {$SET_UNIMP_BITS '18D:00'} // PMCON2
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/CLKIN
+  // Pin  3 : RA4/AN3/T1G/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/CCP1
+  // Pin  6 : RC4
+  // Pin  7 : RC3/AN7
+  // Pin  8 : RC6/AN8/SS
+  // Pin  9 : RC7/AN9/SDO
+  // Pin 10 : RB7/TX/CK
+  // Pin 11 : RB6/SCK/SCL
+  // Pin 12 : RB5/AN11/RX/DT
+  // Pin 13 : RB4/AN10/SDI/SDA
+  // Pin 14 : RC2/AN6
+  // Pin 15 : RC1/AN5
+  // Pin 16 : RC0/AN4
+  // Pin 17 : RA2/AN2/T0CKI/INT
+  // Pin 18 : RA1/AN1/ICSPCLK/ICDCLK
+  // Pin 19 : RA0/AN0/ICSPDAT/ICDDAT
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:1-19,2-18,3-17,4-4,5-3,6-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:1-13,2-12,3-11,4-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : Debugger Mode
+  {$define _DEBUG_ON       = $337A}  // Background debugger is enabled
+  {$define _DEBUG_OFF      = $337B}  // Background debugger is disabled
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_OFF      = $3379}  // INTOSC Frequency is 500 kHz
+  {$define _PLLEN_ON       = $337B}  // INTOSC Frequency is 16 MHz (32x)
+
+  // BOREN : Brown-out Reset Enable bits
+  {$define _BOREN_OFF      = $3373}  // Brown-out Reset disabled (Preconditioned State)
+  {$define _BOREN_NSLEEP   = $337B}  // Brown-out Reset enabled during operation and disabled in Sleep
+  {$define _BOREN_ON       = $337F}  // Brown-out Reset enabled
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_ON          = $336B}  // 0000h to 07FFh code protection on
+  {$define _CP_OFF         = $337B}  // Code protection off
+
+  // MCLRE : RA3/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $337B}  // RA3/MCLR/VPP pin function is MCLR; Weak pull-up enabled.
+  {$define _MCLRE_OFF      = $335B}  // RA3/MCLR/VPP pin function is digital input; MCLR internally disabled; Weak pull-up disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_ON       = $333B}  // PWRT enabled
+  {$define _PWRTE_OFF      = $337B}  // PWRT disabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_OFF       = $337B}  // WDT disabled
+  {$define _WDTE_ON        = $33FB}  // WDT enabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_ECCLK     = $337B}  // EC oscillator: CLKO function on RA4/CLKO pin, CLKI on RA5/CLKI
+  {$define _FOSC_ECIO      = $327B}  // EC oscillator: I/O function on RA4/CLKO pin, CLKI on RA5/CLKI
+  {$define _FOSC_INTOSCCLK = $317B}  // INTOSC oscillator: CLKO function on RA4/CLKO pin, I/O function on RA5/CLKI
+  {$define _FOSC_INTOSCIO  = $307B}  // INTOSCIO oscillator: I/O function on RA4/CLKO pin, I/O function on RA5/CLKI
+
+  // VCAPEN : 
+  {$define _VCAPEN_OFF     = $0013}  // All VCAP pin functions are disabled.
+
+  // WRTEN : Flash memory self-write protection bits
+  {$define _WRTEN_OFF      = $0017}  // Write protection off
+  {$define _WRTEN_BOOT     = $0015}  // 0h to 1FFh of flash memory write protected, 200h to FFFh may be modified
+  {$define _WRTEN_HALF     = $0013}  // 0h to 7FFh of flash memory write protected, 800h to FFFh may be modified
+  {$define _WRTEN_FULL     = $0011}  // 0h to FFFh of flash memory write protected, no address may be modified
+
+implementation
+end.

--- a/PIC16F721.pas
+++ b/PIC16F721.pas
@@ -1,0 +1,424 @@
+unit PIC16F721;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F721'}
+{$SET PIC_MAXFREQ  = 16000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.6;
+  PORTA_RA4         : bit  absolute PORTA.5;
+  PORTA_RA3         : bit  absolute PORTA.4;
+  PORTA_RA2         : bit  absolute PORTA.3;
+  PORTA_RA1         : bit  absolute PORTA.2;
+  PORTA_RA0         : bit  absolute PORTA.1;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.4;
+  PORTB_RB6         : bit  absolute PORTB.3;
+  PORTB_RB5         : bit  absolute PORTB.2;
+  PORTB_RB4         : bit  absolute PORTB.1;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RABIE      : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RABIF      : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_TMR1GIF      : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_TMR1CS1     : bit  absolute T1CON.6;
+  T1CON_TMR1CS0     : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1CKPS0     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1ON      : bit  absolute T1CON.1;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_DC1       : bit  absolute CCP1CON.7;
+  CCP1CON_B1        : bit  absolute CCP1CON.6;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RABPU  : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA2      : bit  absolute TRISA.3;
+  TRISA_TRISA1      : bit  absolute TRISA.2;
+  TRISA_TRISA0      : bit  absolute TRISA.1;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.4;
+  TRISB_TRISB6      : bit  absolute TRISB.3;
+  TRISB_TRISB5      : bit  absolute TRISB.2;
+  TRISB_TRISB4      : bit  absolute TRISB.1;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_TMR1GIE      : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  T1GCON            : byte absolute $008f;
+  T1GCON_TMR1GE     : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL     : bit  absolute T1GCON.6;
+  T1GCON_T1GTM      : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM     : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_DONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL     : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0     : bit  absolute T1GCON.1;
+  OSCCON            : byte absolute $0090;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_ICSL       : bit  absolute OSCCON.3;
+  OSCCON_ICSS       : bit  absolute OSCCON.2;
+  OSCTUNE           : byte absolute $0091;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPADD_ADD7       : bit  absolute SSPADD.7;
+  SSPADD_ADD6       : bit  absolute SSPADD.6;
+  SSPADD_ADD5       : bit  absolute SSPADD.5;
+  SSPADD_ADD4       : bit  absolute SSPADD.4;
+  SSPADD_ADD3       : bit  absolute SSPADD.3;
+  SSPADD_ADD2       : bit  absolute SSPADD.2;
+  SSPADD_ADD1       : bit  absolute SSPADD.1;
+  SSPADD_ADD0       : bit  absolute SSPADD.0;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.7;
+  WPUA_WPUA4        : bit  absolute WPUA.6;
+  WPUA_WPUA3        : bit  absolute WPUA.5;
+  WPUA_WPUA2        : bit  absolute WPUA.4;
+  WPUA_WPUA1        : bit  absolute WPUA.3;
+  WPUA_WPUA0        : bit  absolute WPUA.2;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.7;
+  IOCA_IOCA4        : bit  absolute IOCA.6;
+  IOCA_IOCA3        : bit  absolute IOCA.5;
+  IOCA_IOCA2        : bit  absolute IOCA.4;
+  IOCA_IOCA1        : bit  absolute IOCA.3;
+  IOCA_IOCA0        : bit  absolute IOCA.2;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  FVRCON            : byte absolute $009d;
+  FVRCON_FVRRDY     : bit  absolute FVRCON.7;
+  FVRCON_FVREN      : bit  absolute FVRCON.6;
+  FVRCON_TSEN       : bit  absolute FVRCON.5;
+  FVRCON_TSRNG      : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1     : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0     : bit  absolute FVRCON.2;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.4;
+  ADCON1_ADCS1      : bit  absolute ADCON1.3;
+  ADCON1_ADCS0      : bit  absolute ADCON1.2;
+  PMDATL            : byte absolute $010c;
+  PMADRL            : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  WPUB              : byte absolute $0115;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  IOCB              : byte absolute $0116;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  ANSELA            : byte absolute $0185;
+  ANSELA_ANSA5      : bit  absolute ANSELA.5;
+  ANSELA_ANSA4      : bit  absolute ANSELA.4;
+  ANSELA_ANSA2      : bit  absolute ANSELA.3;
+  ANSELA_ANSA1      : bit  absolute ANSELA.2;
+  ANSELA_ANSA0      : bit  absolute ANSELA.1;
+  ANSELB            : byte absolute $0186;
+  ANSELB_ANSB5      : bit  absolute ANSELB.5;
+  ANSELB_ANSB4      : bit  absolute ANSELB.4;
+  ANSELC            : byte absolute $0187;
+  ANSELC_ANSC7      : bit  absolute ANSELC.7;
+  ANSELC_ANSC6      : bit  absolute ANSELC.6;
+  ANSELC_ANSC3      : bit  absolute ANSELC.5;
+  ANSELC_ANSC2      : bit  absolute ANSELC.4;
+  ANSELC_ANSC1      : bit  absolute ANSELC.3;
+  ANSELC_ANSC0      : bit  absolute ANSELC.2;
+  PMCON1            : byte absolute $018c;
+  PMCON1_CFGS       : bit  absolute PMCON1.6;
+  PMCON1_LWLO       : bit  absolute PMCON1.5;
+  PMCON1_FREE       : bit  absolute PMCON1.4;
+  PMCON1_WREN       : bit  absolute PMCON1.3;
+  PMCON1_WR         : bit  absolute PMCON1.2;
+  PMCON1_RD         : bit  absolute PMCON1.1;
+  PMCON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-01A:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-096:SFR'}  // PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUA, IOCA
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09D-09D:SFR'}  // FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '115-116:SFR'}  // WPUB, IOCB
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB, ANSELC
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, PMCON1, PMCON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:07'} // PMADRH
+  {$SET_UNIMP_BITS '115:F0'} // WPUB
+  {$SET_UNIMP_BITS '116:F0'} // IOCB
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '187:00'} // ANSELC
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+  {$SET_UNIMP_BITS '18D:00'} // PMCON2
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/CLKIN
+  // Pin  3 : RA4/AN3/T1G/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/CCP1
+  // Pin  6 : RC4
+  // Pin  7 : RC3/AN7
+  // Pin  8 : RC6/AN8/SS
+  // Pin  9 : RC7/AN9/SDO
+  // Pin 10 : RB7/TX/CK
+  // Pin 11 : RB6/SCK/SCL
+  // Pin 12 : RB5/AN11/RX/DT
+  // Pin 13 : RB4/AN10/SDI/SDA
+  // Pin 14 : RC2/AN6
+  // Pin 15 : RC1/AN5
+  // Pin 16 : RC0/AN4
+  // Pin 17 : RA2/AN2/T0CKI/INT
+  // Pin 18 : RA1/AN1/ICSPCLK/ICDCLK
+  // Pin 19 : RA0/AN0/ICSPDAT/ICDDAT
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:1-19,2-18,3-17,4-4,5-3,6-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:1-13,2-12,3-11,4-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : Debugger Mode
+  {$define _DEBUG_ON       = $337A}  // Background debugger is enabled
+  {$define _DEBUG_OFF      = $337B}  // Background debugger is disabled
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_OFF      = $3379}  // INTOSC Frequency is 500 kHz
+  {$define _PLLEN_ON       = $337B}  // INTOSC Frequency is 16 MHz (32x)
+
+  // BOREN : Brown-out Reset Enable bits
+  {$define _BOREN_OFF      = $3373}  // Brown-out Reset disabled (Preconditioned State)
+  {$define _BOREN_NSLEEP   = $337B}  // Brown-out Reset enabled during operation and disabled in Sleep
+  {$define _BOREN_ON       = $337F}  // Brown-out Reset enabled
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_ON          = $336B}  // 0000h to 0FFFh code protection on
+  {$define _CP_OFF         = $337B}  // Code protection off
+
+  // MCLRE : RA3/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $337B}  // RA3/MCLR/VPP pin function is MCLR; Weak pull-up enabled.
+  {$define _MCLRE_OFF      = $335B}  // RA3/MCLR/VPP pin function is digital input; MCLR internally disabled; Weak pull-up disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_ON       = $333B}  // PWRT enabled
+  {$define _PWRTE_OFF      = $337B}  // PWRT disabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_OFF       = $337B}  // WDT disabled
+  {$define _WDTE_ON        = $33FB}  // WDT enabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_ECCLK     = $337B}  // EC oscillator: CLKO function on RA4/CLKO pin, CLKI on RA5/CLKI
+  {$define _FOSC_ECIO      = $327B}  // EC oscillator: I/O function on RA4/CLKO pin, CLKI on RA5/CLKI
+  {$define _FOSC_INTOSCCLK = $317B}  // INTOSC oscillator: CLKO function on RA4/CLKO pin, I/O function on RA5/CLKI
+  {$define _FOSC_INTOSCIO  = $307B}  // INTOSCIO oscillator: I/O function on RA4/CLKO pin, I/O function on RA5/CLKI
+
+  // VCAPEN : 
+  {$define _VCAPEN_OFF     = $0013}  // All VCAP pin functions are disabled.
+
+  // WRTEN : Flash memory self-write protection bits
+  {$define _WRTEN_OFF      = $0017}  // Write protection off
+  {$define _WRTEN_BOOT     = $0015}  // 0h to 1FFh of flash memory write protected, 200h to FFFh may be modified
+  {$define _WRTEN_HALF     = $0013}  // 0h to 7FFh of flash memory write protected, 800h to FFFh may be modified
+  {$define _WRTEN_FULL     = $0011}  // 0h to FFFh of flash memory write protected, no address may be modified
+
+implementation
+end.

--- a/PIC16F722.pas
+++ b/PIC16F722.pas
@@ -1,0 +1,458 @@
+unit PIC16F722;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F722'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.3;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-096:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:0F'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/nMCLR/VPP
+  // Pin  2 : RA0/AN0/nSS/VCAP
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/VREF
+  // Pin  6 : RA4/T0CKI/CPS6
+  // Pin  7 : RA5/AN4/CPS7/nSS/VCAP
+  // Pin  8 : VSS
+  // Pin  9 : RA7/OSC1/CLKIN
+  // Pin 10 : RA6/OSC2/CLKOUT/VCAP
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : VSS
+  // Pin 20 : VDD
+  // Pin 21 : RB0/AN12/CPS0/INT
+  // Pin 22 : RB1/AN10/CPS1
+  // Pin 23 : RB2/AN8/CPS2
+  // Pin 24 : RB3/AN9/CPS3/CCP2
+  // Pin 25 : RB4/AN11/CPS4
+  // Pin 26 : RB5/AN13/CPS5/T1G
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F722A.pas
+++ b/PIC16F722A.pas
@@ -1,0 +1,466 @@
+unit PIC16F722A;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F722A'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.1;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  SPBRG_BRG7         : bit  absolute SPBRG.7;
+  SPBRG_BRG6         : bit  absolute SPBRG.6;
+  SPBRG_BRG5         : bit  absolute SPBRG.5;
+  SPBRG_BRG4         : bit  absolute SPBRG.4;
+  SPBRG_BRG3         : bit  absolute SPBRG.3;
+  SPBRG_BRG2         : bit  absolute SPBRG.2;
+  SPBRG_BRG1         : bit  absolute SPBRG.1;
+  SPBRG_BRG0         : bit  absolute SPBRG.0;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-096:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:0F'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/SS/Vcap
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/CPS6/T0CKI
+  // Pin  7 : RA5/AN4/CPS7/SS/Vcap
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKIN
+  // Pin 10 : RA6/OSC2/CLKOUT/Vcap
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/CPS0/INT
+  // Pin 22 : RB1/AN10/CPS1
+  // Pin 23 : RB2/AN8/CPS2
+  // Pin 24 : RB3/AN9/CPS3/CCP2
+  // Pin 25 : RB4/AN11/CPS4
+  // Pin 26 : RB5/AN13/CPS5/T1G
+  // Pin 27 : RB6/ICSPCLK/ICDCLK
+  // Pin 28 : RB7/ICSPDAT/ICDDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-circuit debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-circuit debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLL Enable bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR Pin Function Select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F723.pas
+++ b/PIC16F723.pas
@@ -1,0 +1,458 @@
+unit PIC16F723;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F723'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.3;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-096:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '120-12F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:0F'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/nSS/Vcap
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/CPS6/T0CKI
+  // Pin  7 : RA5/AN4/CPS7/nSS/Vcap
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKIN
+  // Pin 10 : RA6/OSC2/CLKOUT/Vcap
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/CPS0/INT
+  // Pin 22 : RB1/AN10/CPS1
+  // Pin 23 : RB2/AN8/CPS2
+  // Pin 24 : RB3/AN9/CPS3/CCP2
+  // Pin 25 : RB4/AN11/CPS4
+  // Pin 26 : RB5/AN13/CPS5/T1G
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F723A.pas
+++ b/PIC16F723A.pas
@@ -1,0 +1,466 @@
+unit PIC16F723A;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F723A'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.1;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  SPBRG_BRG7         : bit  absolute SPBRG.7;
+  SPBRG_BRG6         : bit  absolute SPBRG.6;
+  SPBRG_BRG5         : bit  absolute SPBRG.5;
+  SPBRG_BRG4         : bit  absolute SPBRG.4;
+  SPBRG_BRG3         : bit  absolute SPBRG.3;
+  SPBRG_BRG2         : bit  absolute SPBRG.2;
+  SPBRG_BRG1         : bit  absolute SPBRG.1;
+  SPBRG_BRG0         : bit  absolute SPBRG.0;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-096:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '120-12F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:0F'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/SS/Vcap
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/CPS6/T0CKI
+  // Pin  7 : RA5/AN4/CPS7/SS/Vcap
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKIN
+  // Pin 10 : RA6/OSC2/CLKOUT/Vcap
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/CPS0/INT
+  // Pin 22 : RB1/AN10/CPS1
+  // Pin 23 : RB2/AN8/CPS2
+  // Pin 24 : RB3/AN9/CPS3/CCP2
+  // Pin 25 : RB4/AN11/CPS4
+  // Pin 26 : RB5/AN13/CPS5/T1G
+  // Pin 27 : RB6/ICSPCLK/ICDCLK
+  // Pin 28 : RB7/ICSPDAT/ICDDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-circuit debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-circuit debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLL Enable bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR Pin Function Select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F724.pas
+++ b/PIC16F724.pas
@@ -1,0 +1,507 @@
+unit PIC16F724;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F724'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTD              : byte absolute $0008;
+  PORTD_RD7          : bit  absolute PORTD.7;
+  PORTD_RD6          : bit  absolute PORTD.6;
+  PORTD_RD5          : bit  absolute PORTD.5;
+  PORTD_RD4          : bit  absolute PORTD.4;
+  PORTD_RD3          : bit  absolute PORTD.3;
+  PORTD_RD2          : bit  absolute PORTD.2;
+  PORTD_RD1          : bit  absolute PORTD.1;
+  PORTD_RD0          : bit  absolute PORTD.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PORTE_RE2          : bit  absolute PORTE.2;
+  PORTE_RE1          : bit  absolute PORTE.1;
+  PORTE_RE0          : bit  absolute PORTE.0;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISD              : byte absolute $0088;
+  TRISD_TRISD7       : bit  absolute TRISD.7;
+  TRISD_TRISD6       : bit  absolute TRISD.6;
+  TRISD_TRISD5       : bit  absolute TRISD.5;
+  TRISD_TRISD4       : bit  absolute TRISD.4;
+  TRISD_TRISD3       : bit  absolute TRISD.3;
+  TRISD_TRISD2       : bit  absolute TRISD.2;
+  TRISD_TRISD1       : bit  absolute TRISD.1;
+  TRISD_TRISD0       : bit  absolute TRISD.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.3;
+  TRISE_TRISE2       : bit  absolute TRISE.2;
+  TRISE_TRISE1       : bit  absolute TRISE.1;
+  TRISE_TRISE0       : bit  absolute TRISE.0;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  ANSELD             : byte absolute $0188;
+  ANSELD_ANSD7       : bit  absolute ANSELD.7;
+  ANSELD_ANSD6       : bit  absolute ANSELD.6;
+  ANSELD_ANSD5       : bit  absolute ANSELD.5;
+  ANSELD_ANSD4       : bit  absolute ANSELD.4;
+  ANSELD_ANSD3       : bit  absolute ANSELD.3;
+  ANSELD_ANSD2       : bit  absolute ANSELD.2;
+  ANSELD_ANSD1       : bit  absolute ANSELD.1;
+  ANSELD_ANSD0       : bit  absolute ANSELD.0;
+  ANSELE             : byte absolute $0189;
+  ANSELE_ANSE2       : bit  absolute ANSELE.2;
+  ANSELE_ANSE1       : bit  absolute ANSELE.1;
+  ANSELE_ANSE0       : bit  absolute ANSELE.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-096:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '120-12F:GPR'} 
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '188-18C:SFR'}  // ANSELD, ANSELE, PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:00'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '189:07'} // ANSELE
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/nSS/Vcap
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/CPS6/T0CKI
+  // Pin  7 : RA5/AN4/CPS7/nSS/Vcap
+  // Pin  8 : RE0/AN5
+  // Pin  9 : RE1/AN6
+  // Pin 10 : RE2/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : RA7/OSC1/CLKIN
+  // Pin 14 : RA6/OSC2/CLKOUT/Vcap
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/CPS8
+  // Pin 20 : RD1/CPS9
+  // Pin 21 : RD2/CPS10
+  // Pin 22 : RD3/CPS11
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/CPS12
+  // Pin 28 : RD5/CPS13
+  // Pin 29 : RD6/CPS14
+  // Pin 30 : RD7/CPS15
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/AN12/CPS0/INT
+  // Pin 34 : RB1/AN10/CPS1
+  // Pin 35 : RB2/AN8/CPS2
+  // Pin 36 : RB3/AN9/CPS3/CCP2
+  // Pin 37 : RB4/AN11/CPS4
+  // Pin 38 : RB5/AN13/CPS5/T1G
+  // Pin 39 : RB6/ICSPCLK
+  // Pin 40 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F726.pas
+++ b/PIC16F726.pas
@@ -1,0 +1,457 @@
+unit PIC16F726;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F726'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.3;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-096:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:0F'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/nSS/Vcap
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/CPS6/T0CKI
+  // Pin  7 : RA5/AN4/CPS7/nSS/Vcap
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKIN
+  // Pin 10 : RA6/OSC2/CLKOUT/Vcap
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/CPS0/INT
+  // Pin 22 : RB1/AN10/CPS1
+  // Pin 23 : RB2/AN8/CPS2
+  // Pin 24 : RB3/AN9/CPS3/CCP2
+  // Pin 25 : RB4/AN11/CPS4
+  // Pin 26 : RB5/AN13/CPS5/T1G
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F727.pas
+++ b/PIC16F727.pas
@@ -1,0 +1,506 @@
+unit PIC16F727;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F727'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF               : byte absolute $0000;
+  TMR0               : byte absolute $0001;
+  PCL                : byte absolute $0002;
+  STATUS             : byte absolute $0003;
+  STATUS_IRP         : bit  absolute STATUS.7;
+  STATUS_RP1         : bit  absolute STATUS.6;
+  STATUS_RP0         : bit  absolute STATUS.5;
+  STATUS_TO          : bit  absolute STATUS.4;
+  STATUS_PD          : bit  absolute STATUS.3;
+  STATUS_Z           : bit  absolute STATUS.2;
+  STATUS_DC          : bit  absolute STATUS.1;
+  STATUS_C           : bit  absolute STATUS.0;
+  FSR                : byte absolute $0004;
+  PORTA              : byte absolute $0005;
+  PORTA_RA7          : bit  absolute PORTA.7;
+  PORTA_RA6          : bit  absolute PORTA.6;
+  PORTA_RA5          : bit  absolute PORTA.5;
+  PORTA_RA4          : bit  absolute PORTA.4;
+  PORTA_RA3          : bit  absolute PORTA.3;
+  PORTA_RA2          : bit  absolute PORTA.2;
+  PORTA_RA1          : bit  absolute PORTA.1;
+  PORTA_RA0          : bit  absolute PORTA.0;
+  PORTB              : byte absolute $0006;
+  PORTB_RB7          : bit  absolute PORTB.7;
+  PORTB_RB6          : bit  absolute PORTB.6;
+  PORTB_RB5          : bit  absolute PORTB.5;
+  PORTB_RB4          : bit  absolute PORTB.4;
+  PORTB_RB3          : bit  absolute PORTB.3;
+  PORTB_RB2          : bit  absolute PORTB.2;
+  PORTB_RB1          : bit  absolute PORTB.1;
+  PORTB_RB0          : bit  absolute PORTB.0;
+  PORTC              : byte absolute $0007;
+  PORTC_RC7          : bit  absolute PORTC.7;
+  PORTC_RC6          : bit  absolute PORTC.6;
+  PORTC_RC5          : bit  absolute PORTC.5;
+  PORTC_RC4          : bit  absolute PORTC.4;
+  PORTC_RC3          : bit  absolute PORTC.3;
+  PORTC_RC2          : bit  absolute PORTC.2;
+  PORTC_RC1          : bit  absolute PORTC.1;
+  PORTC_RC0          : bit  absolute PORTC.0;
+  PORTD              : byte absolute $0008;
+  PORTD_RD7          : bit  absolute PORTD.7;
+  PORTD_RD6          : bit  absolute PORTD.6;
+  PORTD_RD5          : bit  absolute PORTD.5;
+  PORTD_RD4          : bit  absolute PORTD.4;
+  PORTD_RD3          : bit  absolute PORTD.3;
+  PORTD_RD2          : bit  absolute PORTD.2;
+  PORTD_RD1          : bit  absolute PORTD.1;
+  PORTD_RD0          : bit  absolute PORTD.0;
+  PORTE              : byte absolute $0009;
+  PORTE_RE3          : bit  absolute PORTE.3;
+  PORTE_RE2          : bit  absolute PORTE.2;
+  PORTE_RE1          : bit  absolute PORTE.1;
+  PORTE_RE0          : bit  absolute PORTE.0;
+  PCLATH             : byte absolute $000a;
+  INTCON             : byte absolute $000b;
+  INTCON_GIE         : bit  absolute INTCON.7;
+  INTCON_PEIE        : bit  absolute INTCON.6;
+  INTCON_T0IE        : bit  absolute INTCON.5;
+  INTCON_INTE        : bit  absolute INTCON.4;
+  INTCON_RBIE        : bit  absolute INTCON.3;
+  INTCON_T0IF        : bit  absolute INTCON.2;
+  INTCON_INTF        : bit  absolute INTCON.1;
+  INTCON_RBIF        : bit  absolute INTCON.0;
+  PIR1               : byte absolute $000c;
+  PIR1_TMR1GIF       : bit  absolute PIR1.7;
+  PIR1_ADIF          : bit  absolute PIR1.6;
+  PIR1_RCIF          : bit  absolute PIR1.5;
+  PIR1_TXIF          : bit  absolute PIR1.4;
+  PIR1_SSPIF         : bit  absolute PIR1.3;
+  PIR1_CCP1IF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF        : bit  absolute PIR1.1;
+  PIR1_TMR1IF        : bit  absolute PIR1.0;
+  PIR2               : byte absolute $000d;
+  PIR2_CCP2IF        : bit  absolute PIR2.0;
+  TMR1L              : byte absolute $000e;
+  TMR1H              : byte absolute $000f;
+  T1CON              : byte absolute $0010;
+  T1CON_TMR1CS1      : bit  absolute T1CON.6;
+  T1CON_TMR1CS0      : bit  absolute T1CON.5;
+  T1CON_T1CKPS1      : bit  absolute T1CON.4;
+  T1CON_T1OSCEN      : bit  absolute T1CON.3;
+  T1CON_T1SYNC       : bit  absolute T1CON.2;
+  T1CON_TMR1ON       : bit  absolute T1CON.1;
+  TMR2               : byte absolute $0011;
+  T2CON              : byte absolute $0012;
+  T2CON_TOUTPS3      : bit  absolute T2CON.6;
+  T2CON_TOUTPS2      : bit  absolute T2CON.5;
+  T2CON_TOUTPS1      : bit  absolute T2CON.4;
+  T2CON_TOUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON       : bit  absolute T2CON.2;
+  T2CON_T2CKPS0      : bit  absolute T2CON.1;
+  SSPBUF             : byte absolute $0013;
+  SSPCON             : byte absolute $0014;
+  SSPCON_WCOL        : bit  absolute SSPCON.7;
+  SSPCON_SSPOV       : bit  absolute SSPCON.6;
+  SSPCON_SSPEN       : bit  absolute SSPCON.5;
+  SSPCON_CKP         : bit  absolute SSPCON.4;
+  SSPCON_SSPM3       : bit  absolute SSPCON.3;
+  SSPCON_SSPM2       : bit  absolute SSPCON.2;
+  SSPCON_SSPM1       : bit  absolute SSPCON.1;
+  SSPCON_SSPM0       : bit  absolute SSPCON.0;
+  CCPR1L             : byte absolute $0015;
+  CCPR1H             : byte absolute $0016;
+  CCP1CON            : byte absolute $0017;
+  CCP1CON_DC1B1      : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0      : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3     : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2     : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1     : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0     : bit  absolute CCP1CON.0;
+  RCSTA              : byte absolute $0018;
+  RCSTA_SPEN         : bit  absolute RCSTA.7;
+  RCSTA_RX9          : bit  absolute RCSTA.6;
+  RCSTA_SREN         : bit  absolute RCSTA.5;
+  RCSTA_CREN         : bit  absolute RCSTA.4;
+  RCSTA_ADDEN        : bit  absolute RCSTA.3;
+  RCSTA_FERR         : bit  absolute RCSTA.2;
+  RCSTA_OERR         : bit  absolute RCSTA.1;
+  RCSTA_RX9D         : bit  absolute RCSTA.0;
+  TXREG              : byte absolute $0019;
+  RCREG              : byte absolute $001a;
+  CCPR2L             : byte absolute $001b;
+  CCPR2H             : byte absolute $001c;
+  CCP2CON            : byte absolute $001d;
+  CCP2CON_DC2B1      : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0      : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3     : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2     : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1     : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0     : bit  absolute CCP2CON.0;
+  ADRES              : byte absolute $001e;
+  ADCON0             : byte absolute $001f;
+  ADCON0_CHS3        : bit  absolute ADCON0.5;
+  ADCON0_CHS2        : bit  absolute ADCON0.4;
+  ADCON0_CHS1        : bit  absolute ADCON0.3;
+  ADCON0_CHS0        : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE    : bit  absolute ADCON0.1;
+  ADCON0_ADON        : bit  absolute ADCON0.0;
+  OPTION_REG         : byte absolute $0081;
+  OPTION_REG_RBPU    : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG  : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS    : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE    : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA     : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2     : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1     : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0     : bit  absolute OPTION_REG.0;
+  TRISA              : byte absolute $0085;
+  TRISA_TRISA7       : bit  absolute TRISA.7;
+  TRISA_TRISA6       : bit  absolute TRISA.6;
+  TRISA_TRISA5       : bit  absolute TRISA.5;
+  TRISA_TRISA4       : bit  absolute TRISA.4;
+  TRISA_TRISA3       : bit  absolute TRISA.3;
+  TRISA_TRISA2       : bit  absolute TRISA.2;
+  TRISA_TRISA1       : bit  absolute TRISA.1;
+  TRISA_TRISA0       : bit  absolute TRISA.0;
+  TRISB              : byte absolute $0086;
+  TRISB_TRISB7       : bit  absolute TRISB.7;
+  TRISB_TRISB6       : bit  absolute TRISB.6;
+  TRISB_TRISB5       : bit  absolute TRISB.5;
+  TRISB_TRISB4       : bit  absolute TRISB.4;
+  TRISB_TRISB3       : bit  absolute TRISB.3;
+  TRISB_TRISB2       : bit  absolute TRISB.2;
+  TRISB_TRISB1       : bit  absolute TRISB.1;
+  TRISB_TRISB0       : bit  absolute TRISB.0;
+  TRISC              : byte absolute $0087;
+  TRISC_TRISC7       : bit  absolute TRISC.7;
+  TRISC_TRISC6       : bit  absolute TRISC.6;
+  TRISC_TRISC5       : bit  absolute TRISC.5;
+  TRISC_TRISC4       : bit  absolute TRISC.4;
+  TRISC_TRISC3       : bit  absolute TRISC.3;
+  TRISC_TRISC2       : bit  absolute TRISC.2;
+  TRISC_TRISC1       : bit  absolute TRISC.1;
+  TRISC_TRISC0       : bit  absolute TRISC.0;
+  TRISD              : byte absolute $0088;
+  TRISD_TRISD7       : bit  absolute TRISD.7;
+  TRISD_TRISD6       : bit  absolute TRISD.6;
+  TRISD_TRISD5       : bit  absolute TRISD.5;
+  TRISD_TRISD4       : bit  absolute TRISD.4;
+  TRISD_TRISD3       : bit  absolute TRISD.3;
+  TRISD_TRISD2       : bit  absolute TRISD.2;
+  TRISD_TRISD1       : bit  absolute TRISD.1;
+  TRISD_TRISD0       : bit  absolute TRISD.0;
+  TRISE              : byte absolute $0089;
+  TRISE_TRISE3       : bit  absolute TRISE.3;
+  TRISE_TRISE2       : bit  absolute TRISE.2;
+  TRISE_TRISE1       : bit  absolute TRISE.1;
+  TRISE_TRISE0       : bit  absolute TRISE.0;
+  PIE1               : byte absolute $008c;
+  PIE1_TMR1GIE       : bit  absolute PIE1.7;
+  PIE1_ADIE          : bit  absolute PIE1.6;
+  PIE1_RCIE          : bit  absolute PIE1.5;
+  PIE1_TXIE          : bit  absolute PIE1.4;
+  PIE1_SSPIE         : bit  absolute PIE1.3;
+  PIE1_CCP1IE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE        : bit  absolute PIE1.1;
+  PIE1_TMR1IE        : bit  absolute PIE1.0;
+  PIE2               : byte absolute $008d;
+  PIE2_CCP2IE        : bit  absolute PIE2.0;
+  PCON               : byte absolute $008e;
+  PCON_POR           : bit  absolute PCON.1;
+  PCON_BOR           : bit  absolute PCON.0;
+  T1GCON             : byte absolute $008f;
+  T1GCON_TMR1GE      : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL      : bit  absolute T1GCON.6;
+  T1GCON_T1GTM       : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM      : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL      : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0      : bit  absolute T1GCON.1;
+  OSCCON             : byte absolute $0090;
+  OSCCON_IRCF1       : bit  absolute OSCCON.5;
+  OSCCON_IRCF0       : bit  absolute OSCCON.4;
+  OSCCON_ICSL        : bit  absolute OSCCON.3;
+  OSCCON_ICSS        : bit  absolute OSCCON.2;
+  OSCTUNE            : byte absolute $0091;
+  OSCTUNE_TUN5       : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4       : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3       : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2       : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1       : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0       : bit  absolute OSCTUNE.0;
+  PR2                : byte absolute $0092;
+  SSPADD             : byte absolute $0093;
+  SSPMSK             : byte absolute $0093;
+  SSPSTAT            : byte absolute $0094;
+  SSPSTAT_SMP        : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE        : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA       : bit  absolute SSPSTAT.5;
+  SSPSTAT_P          : bit  absolute SSPSTAT.4;
+  SSPSTAT_S          : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW       : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA         : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF         : bit  absolute SSPSTAT.0;
+  WPUB               : byte absolute $0095;
+  WPUB_WPUB7         : bit  absolute WPUB.7;
+  WPUB_WPUB6         : bit  absolute WPUB.6;
+  WPUB_WPUB5         : bit  absolute WPUB.5;
+  WPUB_WPUB4         : bit  absolute WPUB.4;
+  WPUB_WPUB3         : bit  absolute WPUB.3;
+  WPUB_WPUB2         : bit  absolute WPUB.2;
+  WPUB_WPUB1         : bit  absolute WPUB.1;
+  WPUB_WPUB0         : bit  absolute WPUB.0;
+  IOCB               : byte absolute $0096;
+  IOCB_IOCB7         : bit  absolute IOCB.7;
+  IOCB_IOCB6         : bit  absolute IOCB.6;
+  IOCB_IOCB5         : bit  absolute IOCB.5;
+  IOCB_IOCB4         : bit  absolute IOCB.4;
+  IOCB_IOCB3         : bit  absolute IOCB.3;
+  IOCB_IOCB2         : bit  absolute IOCB.2;
+  IOCB_IOCB1         : bit  absolute IOCB.1;
+  IOCB_IOCB0         : bit  absolute IOCB.0;
+  TXSTA              : byte absolute $0098;
+  TXSTA_CSRC         : bit  absolute TXSTA.7;
+  TXSTA_TX9          : bit  absolute TXSTA.6;
+  TXSTA_TXEN         : bit  absolute TXSTA.5;
+  TXSTA_SYNC         : bit  absolute TXSTA.4;
+  TXSTA_BRGH         : bit  absolute TXSTA.3;
+  TXSTA_TRMT         : bit  absolute TXSTA.2;
+  TXSTA_TX9D         : bit  absolute TXSTA.1;
+  SPBRG              : byte absolute $0099;
+  APFCON             : byte absolute $009c;
+  APFCON_SSSEL       : bit  absolute APFCON.1;
+  APFCON_CCP2SEL     : bit  absolute APFCON.0;
+  FVRCON             : byte absolute $009d;
+  FVRCON_FVRRDY      : bit  absolute FVRCON.5;
+  FVRCON_FVREN       : bit  absolute FVRCON.4;
+  FVRCON_ADFVR1      : bit  absolute FVRCON.3;
+  FVRCON_ADFVR0      : bit  absolute FVRCON.2;
+  ADCON1             : byte absolute $009f;
+  ADCON1_ADCS2       : bit  absolute ADCON1.6;
+  ADCON1_ADCS1       : bit  absolute ADCON1.5;
+  ADCON1_ADCS0       : bit  absolute ADCON1.4;
+  ADCON1_ADREF1      : bit  absolute ADCON1.3;
+  ADCON1_ADREF0      : bit  absolute ADCON1.2;
+  CPSCON0            : byte absolute $0108;
+  CPSCON0_CPSON      : bit  absolute CPSCON0.7;
+  CPSCON0_CPSOUT     : bit  absolute CPSCON0.4;
+  CPSCON0_T0XCS      : bit  absolute CPSCON0.3;
+  CPSCON0_CPSRNG0    : bit  absolute CPSCON0.2;
+  CPSCON1            : byte absolute $0109;
+  CPSCON1_CPSCH3     : bit  absolute CPSCON1.3;
+  CPSCON1_CPSCH2     : bit  absolute CPSCON1.2;
+  CPSCON1_CPSCH1     : bit  absolute CPSCON1.1;
+  CPSCON1_CPSCH0     : bit  absolute CPSCON1.0;
+  PMDATL             : byte absolute $010c;
+  PMADRL             : byte absolute $010d;
+  PMDATH             : byte absolute $010e;
+  PMADRH             : byte absolute $010f;
+  ANSELA             : byte absolute $0185;
+  ANSELA_ANSA5       : bit  absolute ANSELA.5;
+  ANSELA_ANSA4       : bit  absolute ANSELA.4;
+  ANSELA_ANSA3       : bit  absolute ANSELA.3;
+  ANSELA_ANSA2       : bit  absolute ANSELA.2;
+  ANSELA_ANSA1       : bit  absolute ANSELA.1;
+  ANSELA_ANSA0       : bit  absolute ANSELA.0;
+  ANSELB             : byte absolute $0186;
+  ANSELB_ANSB5       : bit  absolute ANSELB.5;
+  ANSELB_ANSB4       : bit  absolute ANSELB.4;
+  ANSELB_ANSB3       : bit  absolute ANSELB.3;
+  ANSELB_ANSB2       : bit  absolute ANSELB.2;
+  ANSELB_ANSB1       : bit  absolute ANSELB.1;
+  ANSELB_ANSB0       : bit  absolute ANSELB.0;
+  ANSELD             : byte absolute $0188;
+  ANSELD_ANSD7       : bit  absolute ANSELD.7;
+  ANSELD_ANSD6       : bit  absolute ANSELD.6;
+  ANSELD_ANSD5       : bit  absolute ANSELD.5;
+  ANSELD_ANSD4       : bit  absolute ANSELD.4;
+  ANSELD_ANSD3       : bit  absolute ANSELD.3;
+  ANSELD_ANSD2       : bit  absolute ANSELD.2;
+  ANSELD_ANSD1       : bit  absolute ANSELD.1;
+  ANSELD_ANSD0       : bit  absolute ANSELD.0;
+  ANSELE             : byte absolute $0189;
+  ANSELE_ANSE2       : bit  absolute ANSELE.2;
+  ANSELE_ANSE1       : bit  absolute ANSELE.1;
+  ANSELE_ANSE0       : bit  absolute ANSELE.0;
+  PMCON1             : byte absolute $018c;
+  PMCON1_RD          : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-096:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, T1GCON, OSCCON, OSCTUNE, PR2, SSPMSK, SSPSTAT, WPUB, IOCB
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // APFCON, FVRCON
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '108-10F:SFR'}  // CPSCON0, CPSCON1, PCLATH, INTCON, PMDATL, PMADRL, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-186:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA, ANSELB
+  {$SET_STATE_RAM '188-18C:SFR'}  // ANSELD, ANSELE, PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:FD'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:3F'} // ADCON0
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '090:3C'} // OSCCON
+  {$SET_UNIMP_BITS '091:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09C:03'} // APFCON
+  {$SET_UNIMP_BITS '09D:F3'} // FVRCON
+  {$SET_UNIMP_BITS '09F:73'} // ADCON1
+  {$SET_UNIMP_BITS '108:00'} // CPSCON0
+  {$SET_UNIMP_BITS '109:0F'} // CPSCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '185:3F'} // ANSELA
+  {$SET_UNIMP_BITS '186:3F'} // ANSELB
+  {$SET_UNIMP_BITS '189:07'} // ANSELE
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/nSS/Vcap
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/CPS6/T0CKI
+  // Pin  7 : RA5/AN4/CPS7/nSS/Vcap
+  // Pin  8 : RE0/AN5
+  // Pin  9 : RE1/AN6
+  // Pin 10 : RE2/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : RA7/OSC1/CLKIN
+  // Pin 14 : RA6/OSC2/CLKOUT/Vcap
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/CPS8
+  // Pin 20 : RD1/CPS9
+  // Pin 21 : RD2/CPS10
+  // Pin 22 : RD3/CPS11
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/CPS12
+  // Pin 28 : RD5/CPS13
+  // Pin 29 : RD6/CPS14
+  // Pin 30 : RD7/CPS15
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/AN12/CPS0/INT
+  // Pin 34 : RB1/AN10/CPS1
+  // Pin 35 : RB2/AN8/CPS2
+  // Pin 36 : RB3/AN9/CPS3/CCP2
+  // Pin 37 : RB4/AN11/CPS4
+  // Pin 38 : RB5/AN13/CPS5/T1G
+  // Pin 39 : RB6/ICSPCLK
+  // Pin 40 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3F7F}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $3F7E}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // PLLEN : INTOSC PLLEN Enable Bit
+  {$define _PLLEN_ON       = $3F7F}  // INTOSC Frequency is 16MHz (32x)
+  {$define _PLLEN_OFF      = $3F7D}  // INTOSC Frequency is 500 kHz
+
+  // WDTCS : Watchdog Timer Clock Select
+  {$define _WDTCS_         = $3F7F}  // Standard Watchdog Timer is selected
+  {$define _WDTCS_         = $3F7B}  // Low Power Watchdog Timer is selected
+
+  // BORV : Brown-out Reset Voltage selection bit
+  {$define _BORV_19        = $3F7F}  // Brown-out Reset Voltage (VBOR) set to 1.9 V nominal
+  {$define _BORV_25        = $3F77}  // Brown-out Reset Voltage (VBOR) set to 2.5 V nominal
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $3F7F}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $3F6F}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_OFF      = $3F5F}  // BOR disabled
+  {$define _BOREN_OFF      = $3F4F}  // BOR disabled
+
+  // RES : Reserved
+  {$define _RES_           = $3F7F}  // Reserved
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_OFF      = $3E7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+  {$define _MCLRE_ON       = $3F7F}  // RE3/MCLR pin function is MCLR
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3F7F}  // PWRT disabled
+  {$define _PWRTE_ON       = $3D7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3F7F}  // WDT enabled
+  {$define _WDTE_OFF       = $3B7F}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $3F7F}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRCIO   = $377F}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCCLK = $2F7F}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $277F}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC        = $1F7F}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS        = $177F}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT        = $0F7F}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP        = $077F}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // VCAPEN : Voltage Regulator Capacitor Enable bits
+  {$define _VCAPEN_DIS     = $0033}  // All VCAP pin functions are disabled
+  {$define _VCAPEN_RA6     = $0032}  // VCAP functionality is enabled on RA6
+  {$define _VCAPEN_RA5     = $0031}  // VCAP functionality is enabled on RA5
+  {$define _VCAPEN_RA0     = $0030}  // VCAP functionality is enabled on RA0
+
+implementation
+end.

--- a/PIC16F73.pas
+++ b/PIC16F73.pas
@@ -1,0 +1,337 @@
+unit PIC16F73;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F73'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_CCP2IF       : bit  absolute PIR2.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_FERR        : bit  absolute RCSTA.3;
+  RCSTA_OERR        : bit  absolute RCSTA.2;
+  RCSTA_RX9D        : bit  absolute RCSTA.1;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_CCP2IE       : bit  absolute PIE2.0;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON1            : byte absolute $009f;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-01F:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08E:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '018:F7'} // RCSTA
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:07'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:81'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKI
+  // Pin 10 : OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/PGM
+  // Pin 25 : RB4
+  // Pin 26 : RB5
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON  = $005F}  // BOR enabled
+  {$define _BOREN_OFF = $005E}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bit
+  {$define _CP_OFF    = $005F}  // Code protection off
+  {$define _CP_ON     = $005D}  // All Memory locations code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF = $005F}  // PWRT disabled
+  {$define _PWRTE_ON  = $005B}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON   = $005F}  // WDT enabled
+  {$define _WDTE_OFF  = $0057}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_RC   = $007F}  // RC oscillator
+  {$define _FOSC_HS   = $006F}  // HS oscillator
+  {$define _FOSC_XT   = $005F}  // XT oscillator
+  {$define _FOSC_LP   = $004F}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F737.pas
+++ b/PIC16F737.pas
@@ -1,0 +1,465 @@
+unit PIC16F737;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F737'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_LVDIF        : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP3IF       : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1RUN       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_CHS3       : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_LVDIE        : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP3IE       : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.2;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.5;
+  OSCCON_IRCF1      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCCON_SCS0       : bit  absolute OSCCON.1;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  CCPR3L            : byte absolute $0095;
+  CCPR3H            : byte absolute $0096;
+  CCP3CON           : byte absolute $0097;
+  CCP3CON_CCP3X     : bit  absolute CCP3CON.5;
+  CCP3CON_CCP3Y     : bit  absolute CCP3CON.4;
+  CCP3CON_CCP3M3    : bit  absolute CCP3CON.3;
+  CCP3CON_CCP3M2    : bit  absolute CCP3CON.2;
+  CCP3CON_CCP3M1    : bit  absolute CCP3CON.1;
+  CCP3CON_CCP3M0    : bit  absolute CCP3CON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON2            : byte absolute $009b;
+  ADCON2_ACQT2      : bit  absolute ADCON2.5;
+  ADCON2_ACQT1      : bit  absolute ADCON2.4;
+  ADCON2_ACQT0      : bit  absolute ADCON2.3;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL3      : bit  absolute LVDCON.3;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-099:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPADD, SSPSTAT, CCPR3L, CCPR3H, CCP3CON, TXSTA, SPBRG
+  {$SET_STATE_RAM '09B-09F:SFR'}  // ADCON2, CMCON, CVRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-106:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB
+  {$SET_STATE_RAM '109-10F:SFR'}  // LVDCON, PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:EB'} // PIR2
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:EB'} // PIE2
+  {$SET_UNIMP_BITS '08E:07'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '097:3F'} // CCP3CON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09B:38'} // ADCON2
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:3F'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp/RE3
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-/CVref
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/LVDIN/SS/C2OUT
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKI/RA7
+  // Pin 10 : OSC2/CLKO/RA6
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT/AN12
+  // Pin 22 : RB1/AN10
+  // Pin 23 : RB2/AN8
+  // Pin 24 : RB3/CCP2/AN9
+  // Pin 25 : RB4/AN11
+  // Pin 26 : RB5/AN13/CCP3
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bits
+  {$define _CP_OFF         = $39FF}  // Code protection off
+  {$define _CP_ON          = $39FE}  // 0000h to 0FFFh code-protected
+
+  // CCP2MX : CCP2 Multiplex bit
+  {$define _CCP2MX_RC1     = $39FF}  // CCP2 is on RC1
+  {$define _CCP2MX_RB3     = $39FD}  // CCP2 is on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $39FF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $39FB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // BORV : Brown-out Reset Voltage bits
+  {$define _BORV_20        = $39FF}  // VBOR set to 2.0V
+  {$define _BORV_27        = $39F7}  // VBOR set to 2.7V
+  {$define _BORV_42        = $39EF}  // VBOR set to 4.2V
+  {$define _BORV_45        = $39E7}  // VBOR set to 4.5V
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $39FF}  // Enabled
+  {$define _BOREN_OFF      = $39DF}  // Disabled
+
+  // MCLRE : MCLR/VPP/RE3 Pin Function Select bit
+  {$define _MCLRE_ON       = $39FF}  // MCLR/VPP/RE3 pin function is MCLR
+  {$define _MCLRE_OFF      = $39BF}  // MCLR/VPP/RE3 pin function is digital input only, MCLR gated to '1'
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $39FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $397F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $39FF}  // WDT enabled
+  {$define _WDTE_OFF       = $38FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $27FF}  // EXTRC oscillator; CLKO function on OSC2/CLKO/RA6
+  {$define _FOSC_EXTRCIO   = $25FF}  // EXTRC oscillator; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_INTOSCCLK = $23FF}  // INTRC oscillator; CLKO function on OSC2/CLKO/RA6 and port I/O function on OSC1/CLKI/RA7
+  {$define _FOSC_INTOSCIO  = $21FF}  // INTRC oscillator; port I/O function on OSC1/CLKI/RA7 and OSC2/CLKO/RA6
+  {$define _FOSC_EC        = $07FF}  // EXTCLK; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_HS        = $05FF}  // HS oscillator
+  {$define _FOSC_XT        = $03FF}  // XT oscillator
+  {$define _FOSC_LP        = $01FF}  // LP oscillator
+
+  // BORSEN : Brown-out Reset Software Enable bit
+  {$define _BORSEN_ON      = $0043}  // Enabled
+  {$define _BORSEN_OFF     = $0042}  // Disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0043}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $0041}  // Internal External Switchover mode disabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $0047}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $0043}  // Fail-Safe Clock Monitor disabled
+
+implementation
+end.

--- a/PIC16F74.pas
+++ b/PIC16F74.pas
@@ -1,0 +1,381 @@
+unit PIC16F74;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F74'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_CCP2IF       : bit  absolute PIR2.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_FERR        : bit  absolute RCSTA.3;
+  RCSTA_OERR        : bit  absolute RCSTA.2;
+  RCSTA_RX9D        : bit  absolute RCSTA.1;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE2      : bit  absolute TRISE.3;
+  TRISE_TRISE1      : bit  absolute TRISE.2;
+  TRISE_TRISE0      : bit  absolute TRISE.1;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_CCP2IE       : bit  absolute PIE2.0;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON1            : byte absolute $009f;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-08E:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '009:07'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '018:F7'} // RCSTA
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '089:F7'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:07'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:81'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKI
+  // Pin 14 : OSC2/CLKO
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT
+  // Pin 34 : RB1
+  // Pin 35 : RB2
+  // Pin 36 : RB3/PGM
+  // Pin 37 : RB4
+  // Pin 38 : RB5
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON  = $005F}  // BOR enabled
+  {$define _BOREN_OFF = $005E}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bit
+  {$define _CP_OFF    = $005F}  // Code protection off
+  {$define _CP_ON     = $005D}  // All Memory locations code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF = $005F}  // PWRT disabled
+  {$define _PWRTE_ON  = $005B}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON   = $005F}  // WDT enabled
+  {$define _WDTE_OFF  = $0057}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_RC   = $007F}  // RC oscillator
+  {$define _FOSC_HS   = $006F}  // HS oscillator
+  {$define _FOSC_XT   = $005F}  // XT oscillator
+  {$define _FOSC_LP   = $004F}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F747.pas
+++ b/PIC16F747.pas
@@ -1,0 +1,504 @@
+unit PIC16F747;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F747'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_LVDIF        : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP3IF       : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1RUN       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_CHS3       : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_LVDIE        : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP3IE       : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.2;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.5;
+  OSCCON_IRCF1      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCCON_SCS0       : bit  absolute OSCCON.1;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  CCPR3L            : byte absolute $0095;
+  CCPR3H            : byte absolute $0096;
+  CCP3CON           : byte absolute $0097;
+  CCP3CON_CCP3X     : bit  absolute CCP3CON.5;
+  CCP3CON_CCP3Y     : bit  absolute CCP3CON.4;
+  CCP3CON_CCP3M3    : bit  absolute CCP3CON.3;
+  CCP3CON_CCP3M2    : bit  absolute CCP3CON.2;
+  CCP3CON_CCP3M1    : bit  absolute CCP3CON.1;
+  CCP3CON_CCP3M0    : bit  absolute CCP3CON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON2            : byte absolute $009b;
+  ADCON2_ACQT2      : bit  absolute ADCON2.5;
+  ADCON2_ACQT1      : bit  absolute ADCON2.4;
+  ADCON2_ACQT0      : bit  absolute ADCON2.3;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL3      : bit  absolute LVDCON.3;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-099:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPADD, SSPSTAT, CCPR3L, CCPR3H, CCP3CON, TXSTA, SPBRG
+  {$SET_STATE_RAM '09B-09F:SFR'}  // ADCON2, CMCON, CVRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-106:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB
+  {$SET_STATE_RAM '109-10F:SFR'}  // LVDCON, PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:EB'} // PIR2
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '08D:EB'} // PIE2
+  {$SET_UNIMP_BITS '08E:07'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '097:3F'} // CCP3CON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09B:38'} // ADCON2
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:3F'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp/RE3
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-/CVref
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/LVDIN/SS/C2OUT
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKI/RA7
+  // Pin 14 : OSC2/CLKO/RA6
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT/AN12
+  // Pin 34 : RB1/AN10
+  // Pin 35 : RB2/AN8
+  // Pin 36 : RB3/CCP2/AN9
+  // Pin 37 : RB4/AN11
+  // Pin 38 : RB5/AN13/CCP3
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bits
+  {$define _CP_OFF         = $39FF}  // Code protection off
+  {$define _CP_ON          = $39FE}  // 0000h to 0FFFh code-protected
+
+  // CCP2MX : CCP2 Multiplex bit
+  {$define _CCP2MX_RC1     = $39FF}  // CCP2 is on RC1
+  {$define _CCP2MX_RB3     = $39FD}  // CCP2 is on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $39FF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $39FB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // BORV : Brown-out Reset Voltage bits
+  {$define _BORV_20        = $39FF}  // VBOR set to 2.0V
+  {$define _BORV_27        = $39F7}  // VBOR set to 2.7V
+  {$define _BORV_42        = $39EF}  // VBOR set to 4.2V
+  {$define _BORV_45        = $39E7}  // VBOR set to 4.5V
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $39FF}  // Enabled
+  {$define _BOREN_OFF      = $39DF}  // Disabled
+
+  // MCLRE : MCLR/VPP/RE3 Pin Function Select bit
+  {$define _MCLRE_ON       = $39FF}  // MCLR/VPP/RE3 pin function is MCLR
+  {$define _MCLRE_OFF      = $39BF}  // MCLR/VPP/RE3 pin function is digital input only, MCLR gated to '1'
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $39FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $397F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $39FF}  // WDT enabled
+  {$define _WDTE_OFF       = $38FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $27FF}  // EXTRC oscillator; CLKO function on OSC2/CLKO/RA6
+  {$define _FOSC_EXTRCIO   = $25FF}  // EXTRC oscillator; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_INTOSCCLK = $23FF}  // INTRC oscillator; CLKO function on OSC2/CLKO/RA6 and port I/O function on OSC1/CLKI/RA7
+  {$define _FOSC_INTOSCIO  = $21FF}  // INTRC oscillator; port I/O function on OSC1/CLKI/RA7 and OSC2/CLKO/RA6
+  {$define _FOSC_EC        = $07FF}  // EXTCLK; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_HS        = $05FF}  // HS oscillator
+  {$define _FOSC_XT        = $03FF}  // XT oscillator
+  {$define _FOSC_LP        = $01FF}  // LP oscillator
+
+  // BORSEN : Brown-out Reset Software Enable bit
+  {$define _BORSEN_ON      = $0043}  // Enabled
+  {$define _BORSEN_OFF     = $0042}  // Disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0043}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $0041}  // Internal External Switchover mode disabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $0047}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $0043}  // Fail-Safe Clock Monitor disabled
+
+implementation
+end.

--- a/PIC16F753.pas
+++ b/PIC16F753.pas
@@ -1,0 +1,616 @@
+unit PIC16F753;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F753'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF                : byte absolute $0000;
+  TMR0                : byte absolute $0001;
+  PCL                 : byte absolute $0002;
+  STATUS              : byte absolute $0003;
+  STATUS_IRP          : bit  absolute STATUS.7;
+  STATUS_RP1          : bit  absolute STATUS.6;
+  STATUS_RP0          : bit  absolute STATUS.5;
+  STATUS_TO           : bit  absolute STATUS.4;
+  STATUS_PD           : bit  absolute STATUS.3;
+  STATUS_Z            : bit  absolute STATUS.2;
+  STATUS_DC           : bit  absolute STATUS.1;
+  STATUS_C            : bit  absolute STATUS.0;
+  FSR                 : byte absolute $0004;
+  PORTA               : byte absolute $0005;
+  PORTA_RA5           : bit  absolute PORTA.5;
+  PORTA_RA4           : bit  absolute PORTA.4;
+  PORTA_RA3           : bit  absolute PORTA.3;
+  PORTA_RA2           : bit  absolute PORTA.2;
+  PORTA_RA1           : bit  absolute PORTA.1;
+  PORTA_RA0           : bit  absolute PORTA.0;
+  PORTC               : byte absolute $0007;
+  PORTC_RC5           : bit  absolute PORTC.5;
+  PORTC_RC4           : bit  absolute PORTC.4;
+  PORTC_RC3           : bit  absolute PORTC.3;
+  PORTC_RC2           : bit  absolute PORTC.2;
+  PORTC_RC1           : bit  absolute PORTC.1;
+  PORTC_RC0           : bit  absolute PORTC.0;
+  IOCAF               : byte absolute $0008;
+  IOCAF_IOCAF5        : bit  absolute IOCAF.5;
+  IOCAF_IOCAF4        : bit  absolute IOCAF.4;
+  IOCAF_IOCAF3        : bit  absolute IOCAF.3;
+  IOCAF_IOCAF2        : bit  absolute IOCAF.2;
+  IOCAF_IOCAF1        : bit  absolute IOCAF.1;
+  IOCAF_IOCAF0        : bit  absolute IOCAF.0;
+  IOCCF               : byte absolute $0009;
+  IOCCF_IOCCF5        : bit  absolute IOCCF.5;
+  IOCCF_IOCCF4        : bit  absolute IOCCF.4;
+  IOCCF_IOCCF3        : bit  absolute IOCCF.3;
+  IOCCF_IOCCF2        : bit  absolute IOCCF.2;
+  IOCCF_IOCCF1        : bit  absolute IOCCF.1;
+  IOCCF_IOCCF0        : bit  absolute IOCCF.0;
+  PCLATH              : byte absolute $000a;
+  INTCON              : byte absolute $000b;
+  INTCON_GIE          : bit  absolute INTCON.7;
+  INTCON_PEIE         : bit  absolute INTCON.6;
+  INTCON_T0IE         : bit  absolute INTCON.5;
+  INTCON_INTE         : bit  absolute INTCON.4;
+  INTCON_IOCIE        : bit  absolute INTCON.3;
+  INTCON_T0IF         : bit  absolute INTCON.2;
+  INTCON_INTF         : bit  absolute INTCON.1;
+  INTCON_IOCIF        : bit  absolute INTCON.0;
+  PIR1                : byte absolute $000c;
+  PIR1_TMR1GIF        : bit  absolute PIR1.6;
+  PIR1_ADIF           : bit  absolute PIR1.5;
+  PIR1_HLTMR2IF       : bit  absolute PIR1.4;
+  PIR1_HLTMR1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF         : bit  absolute PIR1.2;
+  PIR1_TMR1IF         : bit  absolute PIR1.1;
+  PIR2                : byte absolute $000d;
+  PIR2_C2IF           : bit  absolute PIR2.4;
+  PIR2_C1IF           : bit  absolute PIR2.3;
+  PIR2_COG1IF         : bit  absolute PIR2.2;
+  PIR2_CCP1IF         : bit  absolute PIR2.1;
+  TMR1L               : byte absolute $000f;
+  TMR1H               : byte absolute $0010;
+  T1CON               : byte absolute $0011;
+  T1CON_TMR1CS1       : bit  absolute T1CON.7;
+  T1CON_TMR1CS0       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1       : bit  absolute T1CON.5;
+  T1CON_T1CKPS0       : bit  absolute T1CON.4;
+  T1CON_T1OSCEN       : bit  absolute T1CON.3;
+  T1CON_T1SYNC        : bit  absolute T1CON.2;
+  T1CON_TMR1ON        : bit  absolute T1CON.1;
+  T1GCON              : byte absolute $0012;
+  T1GCON_TMR1GE       : bit  absolute T1GCON.7;
+  T1GCON_T1GPOL       : bit  absolute T1GCON.6;
+  T1GCON_T1GTM        : bit  absolute T1GCON.5;
+  T1GCON_T1GSPM       : bit  absolute T1GCON.4;
+  T1GCON_T1GGO_nDONE  : bit  absolute T1GCON.3;
+  T1GCON_T1GVAL       : bit  absolute T1GCON.2;
+  T1GCON_T1GSS0       : bit  absolute T1GCON.1;
+  CCPR1L              : byte absolute $0013;
+  CCPR1H              : byte absolute $0014;
+  CCP1CON             : byte absolute $0015;
+  CCP1CON_DC1B1       : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0       : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3      : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2      : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1      : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0      : bit  absolute CCP1CON.0;
+  ADRESL              : byte absolute $001c;
+  ADRESH              : byte absolute $001d;
+  ADCON0              : byte absolute $001e;
+  ADCON0_ADFM         : bit  absolute ADCON0.7;
+  ADCON0_CHS3         : bit  absolute ADCON0.4;
+  ADCON0_CHS2         : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE     : bit  absolute ADCON0.2;
+  ADCON0_ADON         : bit  absolute ADCON0.1;
+  ADCON1              : byte absolute $001f;
+  ADCON1_ADCS2        : bit  absolute ADCON1.6;
+  ADCON1_ADCS1        : bit  absolute ADCON1.5;
+  ADCON1_ADCS0        : bit  absolute ADCON1.4;
+  ADCON1_ADPREF1      : bit  absolute ADCON1.3;
+  OPTION_REG          : byte absolute $0081;
+  OPTION_REG_RAPU     : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG   : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS     : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE     : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA      : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2      : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1      : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0      : bit  absolute OPTION_REG.0;
+  TRISA               : byte absolute $0085;
+  TRISA_TRISA5        : bit  absolute TRISA.5;
+  TRISA_TRISA4        : bit  absolute TRISA.4;
+  TRISA_TRISA3        : bit  absolute TRISA.3;
+  TRISA_TRISA2        : bit  absolute TRISA.2;
+  TRISA_TRISA1        : bit  absolute TRISA.1;
+  TRISA_TRISA0        : bit  absolute TRISA.0;
+  TRISC               : byte absolute $0087;
+  TRISC_TRISC5        : bit  absolute TRISC.5;
+  TRISC_TRISC4        : bit  absolute TRISC.4;
+  TRISC_TRISC3        : bit  absolute TRISC.3;
+  TRISC_TRISC2        : bit  absolute TRISC.2;
+  TRISC_TRISC1        : bit  absolute TRISC.1;
+  TRISC_TRISC0        : bit  absolute TRISC.0;
+  IOCAP               : byte absolute $0088;
+  IOCAP_IOCAP5        : bit  absolute IOCAP.5;
+  IOCAP_IOCAP4        : bit  absolute IOCAP.4;
+  IOCAP_IOCAP3        : bit  absolute IOCAP.3;
+  IOCAP_IOCAP2        : bit  absolute IOCAP.2;
+  IOCAP_IOCAP1        : bit  absolute IOCAP.1;
+  IOCAP_IOCAP0        : bit  absolute IOCAP.0;
+  IOCCP               : byte absolute $0089;
+  IOCCP_IOCCP5        : bit  absolute IOCCP.5;
+  IOCCP_IOCCP4        : bit  absolute IOCCP.4;
+  IOCCP_IOCCP3        : bit  absolute IOCCP.3;
+  IOCCP_IOCCP2        : bit  absolute IOCCP.2;
+  IOCCP_IOCCP1        : bit  absolute IOCCP.1;
+  IOCCP_IOCCP0        : bit  absolute IOCCP.0;
+  PIE1                : byte absolute $008c;
+  PIE1_TMR1GIE        : bit  absolute PIE1.6;
+  PIE1_ADIE           : bit  absolute PIE1.5;
+  PIE1_HLTMR2IE       : bit  absolute PIE1.4;
+  PIE1_HLTMR1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE         : bit  absolute PIE1.2;
+  PIE1_TMR1IE         : bit  absolute PIE1.1;
+  PIE2                : byte absolute $008d;
+  PIE2_C2IE           : bit  absolute PIE2.4;
+  PIE2_C1IE           : bit  absolute PIE2.3;
+  PIE2_COG1IE         : bit  absolute PIE2.2;
+  PIE2_CCP1IE         : bit  absolute PIE2.1;
+  OSCCON              : byte absolute $008f;
+  OSCCON_IRCF1        : bit  absolute OSCCON.5;
+  OSCCON_IRCF0        : bit  absolute OSCCON.4;
+  OSCCON_HTS          : bit  absolute OSCCON.2;
+  OSCCON_LTS          : bit  absolute OSCCON.1;
+  FVR1CON0            : byte absolute $0090;
+  FVR1CON0_FVREN      : bit  absolute FVR1CON0.7;
+  FVR1CON0_FVRRDY     : bit  absolute FVR1CON0.6;
+  FVR1CON0_FVROE      : bit  absolute FVR1CON0.5;
+  FVR1CON0_FVRBUSS1   : bit  absolute FVR1CON0.4;
+  FVR1CON0_FVRBUSS0   : bit  absolute FVR1CON0.3;
+  FVR1CON0_FVRBUFEN   : bit  absolute FVR1CON0.2;
+  DAC1CON0            : byte absolute $0091;
+  DAC1CON0_DACEN      : bit  absolute DAC1CON0.6;
+  DAC1CON0_DACFM      : bit  absolute DAC1CON0.5;
+  DAC1CON0_DACOE      : bit  absolute DAC1CON0.4;
+  DAC1CON0_DACPSS1    : bit  absolute DAC1CON0.3;
+  DAC1CON0_DACPSS0    : bit  absolute DAC1CON0.2;
+  DAC1REFL            : byte absolute $0092;
+  DAC1REFH            : byte absolute $0093;
+  OPA1CON             : byte absolute $0096;
+  OPA1CON_OPAEN       : bit  absolute OPA1CON.7;
+  OPA1CON_OPAUGM      : bit  absolute OPA1CON.6;
+  OPA1CON_OPA1NCH1    : bit  absolute OPA1CON.3;
+  OPA1CON_OPA1NCH0    : bit  absolute OPA1CON.2;
+  OPA1CON_OPA1PCH1    : bit  absolute OPA1CON.1;
+  OPA1CON_OPA1PCH0    : bit  absolute OPA1CON.0;
+  CM2CON0             : byte absolute $009b;
+  CM2CON0_C2ON        : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT       : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE        : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL       : bit  absolute CM2CON0.4;
+  CM2CON0_C2ZLF       : bit  absolute CM2CON0.3;
+  CM2CON0_C2SP        : bit  absolute CM2CON0.2;
+  CM2CON0_C2HYS       : bit  absolute CM2CON0.1;
+  CM2CON0_C2SYNC      : bit  absolute CM2CON0.0;
+  CM2CON1             : byte absolute $009c;
+  CM2CON1_C2INTP      : bit  absolute CM2CON1.7;
+  CM2CON1_C2INTN      : bit  absolute CM2CON1.6;
+  CM2CON1_C2PCH2      : bit  absolute CM2CON1.5;
+  CM2CON1_C2PCH1      : bit  absolute CM2CON1.4;
+  CM2CON1_C2PCH0      : bit  absolute CM2CON1.3;
+  CM2CON1_C2NCH2      : bit  absolute CM2CON1.2;
+  CM2CON1_C2NCH1      : bit  absolute CM2CON1.1;
+  CM2CON1_C2NCH0      : bit  absolute CM2CON1.0;
+  CM1CON0             : byte absolute $009d;
+  CM1CON0_C1ON        : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT       : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE        : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL       : bit  absolute CM1CON0.4;
+  CM1CON0_C1ZLF       : bit  absolute CM1CON0.3;
+  CM1CON0_C1SP        : bit  absolute CM1CON0.2;
+  CM1CON0_C1HYS       : bit  absolute CM1CON0.1;
+  CM1CON0_C1SYNC      : bit  absolute CM1CON0.0;
+  CM1CON1             : byte absolute $009e;
+  CM1CON1_C1INTP      : bit  absolute CM1CON1.7;
+  CM1CON1_C1INTN      : bit  absolute CM1CON1.6;
+  CM1CON1_C1PCH2      : bit  absolute CM1CON1.5;
+  CM1CON1_C1PCH1      : bit  absolute CM1CON1.4;
+  CM1CON1_C1PCH0      : bit  absolute CM1CON1.3;
+  CM1CON1_C1NCH2      : bit  absolute CM1CON1.2;
+  CM1CON1_C1NCH1      : bit  absolute CM1CON1.1;
+  CM1CON1_C1NCH0      : bit  absolute CM1CON1.0;
+  CMOUT               : byte absolute $009f;
+  CMOUT_MCOUT2        : bit  absolute CMOUT.1;
+  CMOUT_MCOUT1        : bit  absolute CMOUT.0;
+  LATA                : byte absolute $0105;
+  LATA_LATA5          : bit  absolute LATA.5;
+  LATA_LATA4          : bit  absolute LATA.4;
+  LATA_LATA2          : bit  absolute LATA.3;
+  LATA_LATA1          : bit  absolute LATA.2;
+  LATA_LATA0          : bit  absolute LATA.1;
+  LATC                : byte absolute $0107;
+  LATC_LATC5          : bit  absolute LATC.5;
+  LATC_LATC4          : bit  absolute LATC.4;
+  LATC_LATC3          : bit  absolute LATC.3;
+  LATC_LATC2          : bit  absolute LATC.2;
+  LATC_LATC1          : bit  absolute LATC.1;
+  LATC_LATC0          : bit  absolute LATC.0;
+  IOCAN               : byte absolute $0108;
+  IOCAN_IOCAN5        : bit  absolute IOCAN.5;
+  IOCAN_IOCAN4        : bit  absolute IOCAN.4;
+  IOCAN_IOCAN3        : bit  absolute IOCAN.3;
+  IOCAN_IOCAN2        : bit  absolute IOCAN.2;
+  IOCAN_IOCAN1        : bit  absolute IOCAN.1;
+  IOCAN_IOCAN0        : bit  absolute IOCAN.0;
+  IOCCN               : byte absolute $0109;
+  IOCCN_IOCCN5        : bit  absolute IOCCN.5;
+  IOCCN_IOCCN4        : bit  absolute IOCCN.4;
+  IOCCN_IOCCN3        : bit  absolute IOCCN.3;
+  IOCCN_IOCCN2        : bit  absolute IOCCN.2;
+  IOCCN_IOCCN1        : bit  absolute IOCCN.1;
+  IOCCN_IOCCN0        : bit  absolute IOCCN.0;
+  WPUA                : byte absolute $010c;
+  WPUA_WPUA5          : bit  absolute WPUA.5;
+  WPUA_WPUA4          : bit  absolute WPUA.4;
+  WPUA_WPUA3          : bit  absolute WPUA.3;
+  WPUA_WPUA2          : bit  absolute WPUA.2;
+  WPUA_WPUA1          : bit  absolute WPUA.1;
+  WPUA_WPUA0          : bit  absolute WPUA.0;
+  WPUC                : byte absolute $010d;
+  WPUC_WPUC5          : bit  absolute WPUC.5;
+  WPUC_WPUC4          : bit  absolute WPUC.4;
+  WPUC_WPUC3          : bit  absolute WPUC.3;
+  WPUC_WPUC2          : bit  absolute WPUC.2;
+  WPUC_WPUC1          : bit  absolute WPUC.1;
+  WPUC_WPUC0          : bit  absolute WPUC.0;
+  SLRCONC             : byte absolute $010e;
+  SLRCONC_SLRC5       : bit  absolute SLRCONC.2;
+  SLRCONC_SLRC4       : bit  absolute SLRCONC.1;
+  PCON                : byte absolute $010f;
+  PCON_POR            : bit  absolute PCON.1;
+  PCON_BOR            : bit  absolute PCON.0;
+  TMR2                : byte absolute $0110;
+  PR2                 : byte absolute $0111;
+  T2CON               : byte absolute $0112;
+  T2CON_T2OUTPS3      : bit  absolute T2CON.6;
+  T2CON_T2OUTPS2      : bit  absolute T2CON.5;
+  T2CON_T2OUTPS1      : bit  absolute T2CON.4;
+  T2CON_T2OUTPS0      : bit  absolute T2CON.3;
+  T2CON_TMR2ON        : bit  absolute T2CON.2;
+  T2CON_T2CKPS0       : bit  absolute T2CON.1;
+  HLTMR1              : byte absolute $0113;
+  HLTPR1              : byte absolute $0114;
+  HLT1CON0            : byte absolute $0115;
+  HLT1CON0_H1OUTPS3   : bit  absolute HLT1CON0.6;
+  HLT1CON0_H1OUTPS2   : bit  absolute HLT1CON0.5;
+  HLT1CON0_H1OUTPS1   : bit  absolute HLT1CON0.4;
+  HLT1CON0_H1OUTPS0   : bit  absolute HLT1CON0.3;
+  HLT1CON0_H1ON       : bit  absolute HLT1CON0.2;
+  HLT1CON0_H1CKPS0    : bit  absolute HLT1CON0.1;
+  HLT1CON1            : byte absolute $0116;
+  HLT1CON1_H1FES      : bit  absolute HLT1CON1.7;
+  HLT1CON1_H1RES      : bit  absolute HLT1CON1.6;
+  HLT1CON1_H1ERS2     : bit  absolute HLT1CON1.4;
+  HLT1CON1_H1ERS1     : bit  absolute HLT1CON1.3;
+  HLT1CON1_H1FEREN    : bit  absolute HLT1CON1.2;
+  HLT1CON1_H1REREN    : bit  absolute HLT1CON1.1;
+  HLTMR2              : byte absolute $0117;
+  HLTPR2              : byte absolute $0118;
+  HLT2CON0            : byte absolute $0119;
+  HLT2CON0_H2OUTPS3   : bit  absolute HLT2CON0.6;
+  HLT2CON0_H2OUTPS2   : bit  absolute HLT2CON0.5;
+  HLT2CON0_H2OUTPS1   : bit  absolute HLT2CON0.4;
+  HLT2CON0_H2OUTPS0   : bit  absolute HLT2CON0.3;
+  HLT2CON0_H2ON       : bit  absolute HLT2CON0.2;
+  HLT2CON0_H2CKPS0    : bit  absolute HLT2CON0.1;
+  HLT2CON1            : byte absolute $011a;
+  HLT2CON1_H2FES      : bit  absolute HLT2CON1.7;
+  HLT2CON1_H2RES      : bit  absolute HLT2CON1.6;
+  HLT2CON1_H2ERS2     : bit  absolute HLT2CON1.4;
+  HLT2CON1_H2ERS1     : bit  absolute HLT2CON1.3;
+  HLT2CON1_H2FEREN    : bit  absolute HLT2CON1.2;
+  HLT2CON1_H2REREN    : bit  absolute HLT2CON1.1;
+  SLPC1CON0           : byte absolute $011e;
+  SLPC1CON0_SC1EN     : bit  absolute SLPC1CON0.6;
+  SLPC1CON0_SC1MRPE   : bit  absolute SLPC1CON0.5;
+  SLPC1CON0_SC1POL    : bit  absolute SLPC1CON0.4;
+  SLPC1CON0_SCS1TSS1  : bit  absolute SLPC1CON0.3;
+  SLPC1CON0_SCS1TSS0  : bit  absolute SLPC1CON0.2;
+  SLPC1CON0_SC1INS    : bit  absolute SLPC1CON0.1;
+  SLPC1CON1           : byte absolute $011f;
+  SLPC1CON1_SC1RNG    : bit  absolute SLPC1CON1.4;
+  SLPC1CON1_SC1ISET2  : bit  absolute SLPC1CON1.3;
+  SLPC1CON1_SC1ISET1  : bit  absolute SLPC1CON1.2;
+  SLPC1CON1_SC1ISET0  : bit  absolute SLPC1CON1.1;
+  ANSELA              : byte absolute $0185;
+  ANSELA_ANSA4        : bit  absolute ANSELA.4;
+  ANSELA_ANSA2        : bit  absolute ANSELA.3;
+  ANSELA_ANSA1        : bit  absolute ANSELA.2;
+  ANSELA_ANSA0        : bit  absolute ANSELA.1;
+  ANSELC              : byte absolute $0187;
+  ANSELC_ANSC3        : bit  absolute ANSELC.3;
+  ANSELC_ANSC2        : bit  absolute ANSELC.2;
+  ANSELC_ANSC1        : bit  absolute ANSELC.1;
+  ANSELC_ANSC0        : bit  absolute ANSELC.0;
+  APFCON              : byte absolute $0188;
+  APFCON_T1GSEL       : bit  absolute APFCON.1;
+  OSCTUNE             : byte absolute $0189;
+  OSCTUNE_TUN4        : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3        : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2        : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1        : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0        : bit  absolute OSCTUNE.0;
+  PMCON1              : byte absolute $018c;
+  PMCON1_WREN         : bit  absolute PMCON1.3;
+  PMCON1_WR           : bit  absolute PMCON1.2;
+  PMCON1_RD           : bit  absolute PMCON1.1;
+  PMCON2              : byte absolute $018d;
+  PMADRL              : byte absolute $018e;
+  PMADRH              : byte absolute $018f;
+  PMDATL              : byte absolute $0190;
+  PMDATH              : byte absolute $0191;
+  COG1PHR             : byte absolute $0192;
+  COG1PHR_G1PHR3      : bit  absolute COG1PHR.3;
+  COG1PHR_G1PHR2      : bit  absolute COG1PHR.2;
+  COG1PHR_G1PHR1      : bit  absolute COG1PHR.1;
+  COG1PHR_G1PHR0      : bit  absolute COG1PHR.0;
+  COG1PHF             : byte absolute $0193;
+  COG1PHF_G1PHF3      : bit  absolute COG1PHF.4;
+  COG1PHF_G1PHF2      : bit  absolute COG1PHF.3;
+  COG1PHF_G1PHF1      : bit  absolute COG1PHF.2;
+  COG1PHF_G1PHF0      : bit  absolute COG1PHF.1;
+  COG1BKR             : byte absolute $0194;
+  COG1BKR_G1BKR3      : bit  absolute COG1BKR.4;
+  COG1BKR_G1BKR2      : bit  absolute COG1BKR.3;
+  COG1BKR_G1BKR1      : bit  absolute COG1BKR.2;
+  COG1BKR_G1BKR0      : bit  absolute COG1BKR.1;
+  COG1BKF             : byte absolute $0195;
+  COG1BKF_G1BKF3      : bit  absolute COG1BKF.3;
+  COG1BKF_G1BKF2      : bit  absolute COG1BKF.2;
+  COG1BKF_G1BKF1      : bit  absolute COG1BKF.1;
+  COG1BKF_G1BKF0      : bit  absolute COG1BKF.0;
+  COG1DBR             : byte absolute $0196;
+  COG1DBR_G1DBR3      : bit  absolute COG1DBR.4;
+  COG1DBR_G1DBR2      : bit  absolute COG1DBR.3;
+  COG1DBR_G1DBR1      : bit  absolute COG1DBR.2;
+  COG1DBR_G1DBR0      : bit  absolute COG1DBR.1;
+  COG1DBF             : byte absolute $0197;
+  COG1DBF_G1DBF3      : bit  absolute COG1DBF.3;
+  COG1DBF_G1DBF2      : bit  absolute COG1DBF.2;
+  COG1DBF_G1DBF1      : bit  absolute COG1DBF.1;
+  COG1DBF_G1DBF0      : bit  absolute COG1DBF.0;
+  COG1CON0            : byte absolute $0198;
+  COG1CON0_G1EN       : bit  absolute COG1CON0.7;
+  COG1CON0_G1OE1      : bit  absolute COG1CON0.6;
+  COG1CON0_G1OE0      : bit  absolute COG1CON0.5;
+  COG1CON0_G1POL1     : bit  absolute COG1CON0.4;
+  COG1CON0_G1POL0     : bit  absolute COG1CON0.3;
+  COG1CON0_G1LD       : bit  absolute COG1CON0.2;
+  COG1CON0_G1MD       : bit  absolute COG1CON0.1;
+  COG1CON1            : byte absolute $0199;
+  COG1CON1_G1RDBTS    : bit  absolute COG1CON1.7;
+  COG1CON1_G1FDBTS    : bit  absolute COG1CON1.6;
+  COG1CON1_G1CS1      : bit  absolute COG1CON1.1;
+  COG1CON1_G1CS0      : bit  absolute COG1CON1.0;
+  COG1RIS             : byte absolute $019a;
+  COG1RIS_G1RIHLT2    : bit  absolute COG1RIS.7;
+  COG1RIS_G1R1HLT1    : bit  absolute COG1RIS.6;
+  COG1RIS_G1RIT2M     : bit  absolute COG1RIS.5;
+  COG1RIS_G1RIFLT     : bit  absolute COG1RIS.4;
+  COG1RIS_C1RICCP1    : bit  absolute COG1RIS.3;
+  COG1RIS_G1RIC2      : bit  absolute COG1RIS.2;
+  COG1RIS_G1RIC1      : bit  absolute COG1RIS.1;
+  COG1RSIM            : byte absolute $019b;
+  COG1RSIM_G1RMHLT2   : bit  absolute COG1RSIM.7;
+  COG1RSIM_G1RMHLT1   : bit  absolute COG1RSIM.6;
+  COG1RSIM_G1RTM2M    : bit  absolute COG1RSIM.5;
+  COG1RSIM_G1RMFLT    : bit  absolute COG1RSIM.4;
+  COG1RSIM_G1RMCCP1   : bit  absolute COG1RSIM.3;
+  COG1RSIM_G1RMC2     : bit  absolute COG1RSIM.2;
+  COG1RSIM_G1RMC1     : bit  absolute COG1RSIM.1;
+  COG1FIS             : byte absolute $019c;
+  COG1FIS_G1FIHLT2    : bit  absolute COG1FIS.7;
+  COG1FIS_G1FIHLT1    : bit  absolute COG1FIS.6;
+  COG1FIS_G1FIT2M     : bit  absolute COG1FIS.5;
+  COG1FIS_G1FIFLT     : bit  absolute COG1FIS.4;
+  COG1FIS_G1FICCP1    : bit  absolute COG1FIS.3;
+  COG1FIS_G1FIC2      : bit  absolute COG1FIS.2;
+  COG1FIS_G1FIC1      : bit  absolute COG1FIS.1;
+  COG1FSIM            : byte absolute $019d;
+  COG1FSIM_G1FMHLT2   : bit  absolute COG1FSIM.7;
+  COG1FSIM_G1FMHLT1   : bit  absolute COG1FSIM.6;
+  COG1FSIM_G1FMT2M    : bit  absolute COG1FSIM.5;
+  COG1FSIM_G1FMFLT    : bit  absolute COG1FSIM.4;
+  COG1FSIM_G1FMCCP1   : bit  absolute COG1FSIM.3;
+  COG1FSIM_G1FMC2     : bit  absolute COG1FSIM.2;
+  COG1FSIM_G1FMC1     : bit  absolute COG1FSIM.1;
+  COG1ASD0            : byte absolute $019e;
+  COG1ASD0_G1ASDE     : bit  absolute COG1ASD0.7;
+  COG1ASD0_G1ARSEN    : bit  absolute COG1ASD0.6;
+  COG1ASD0_G1ASD1L1   : bit  absolute COG1ASD0.5;
+  COG1ASD0_G1ASD1L0   : bit  absolute COG1ASD0.4;
+  COG1ASD0_G1ASD0L1   : bit  absolute COG1ASD0.3;
+  COG1ASD0_G1ASD0L0   : bit  absolute COG1ASD0.2;
+  COG1ASD1            : byte absolute $019f;
+  COG1ASD1_G1ASDSHLT2 : bit  absolute COG1ASD1.5;
+  COG1ASD1_G1ASDSHLT1 : bit  absolute COG1ASD1.4;
+  COG1ASD1_G1ASDSC2   : bit  absolute COG1ASD1.3;
+  COG1ASD1_G1ASDSC1   : bit  absolute COG1ASD1.2;
+  COG1ASD1_G1ASDSFLT  : bit  absolute COG1ASD1.1;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-005:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA
+  {$SET_STATE_RAM '007-00D:SFR'}  // PORTC, IOCAF, IOCCF, PCLATH, INTCON, PIR1, PIR2
+  {$SET_STATE_RAM '00F-015:SFR'}  // TMR1L, TMR1H, T1CON, T1GCON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '01C-01F:SFR'}  // ADRESL, ADRESH, ADCON0, ADCON1
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-085:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA
+  {$SET_STATE_RAM '087-08D:SFR'}  // TRISC, IOCAP, IOCCP, PCLATH, INTCON, PIE1, PIE2
+  {$SET_STATE_RAM '08F-093:SFR'}  // OSCCON, FVR1CON0, DAC1CON0, DAC1REFL, DAC1REFH
+  {$SET_STATE_RAM '096-096:SFR'}  // OPA1CON
+  {$SET_STATE_RAM '09B-09F:SFR'}  // CM2CON0, CM2CON1, CM1CON0, CM1CON1, CMOUT
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-105:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, LATA
+  {$SET_STATE_RAM '107-11A:SFR'}  // LATC, IOCAN, IOCCN, PCLATH, INTCON, WPUA, WPUC, SLRCONC, PCON, TMR2, PR2, T2CON, HLTMR1, HLTPR1, HLT1CON0, HLT1CON1, HLTMR2, HLTPR2, HLT2CON0, HLT2CON1
+  {$SET_STATE_RAM '11E-11F:SFR'}  // SLPC1CON0, SLPC1CON1
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-185:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, ANSELA
+  {$SET_STATE_RAM '187-19F:SFR'}  // ANSELC, APFCON, OSCTUNE, PCLATH, INTCON, PMCON1, PMCON2, PMADRL, PMADRH, PMDATL, PMDATH, COG1PHR, COG1PHF, COG1BKR, COG1BKF, COG1DBR, COG1DBF, COG1CON0, COG1CON1, COG1RIS, COG1RSIM, COG1FIS, COG1FSIM, COG1ASD0, COG1ASD1
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '008:3F'} // IOCAF
+  {$SET_UNIMP_BITS '009:3F'} // IOCCF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:CF'} // PIR1
+  {$SET_UNIMP_BITS '00D:35'} // PIR2
+  {$SET_UNIMP_BITS '011:F0'} // T1CON
+  {$SET_UNIMP_BITS '012:03'} // T1GCON
+  {$SET_UNIMP_BITS '015:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01E:BF'} // ADCON0
+  {$SET_UNIMP_BITS '01F:71'} // ADCON1
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '087:3F'} // TRISC
+  {$SET_UNIMP_BITS '088:3F'} // IOCAP
+  {$SET_UNIMP_BITS '089:3F'} // IOCCP
+  {$SET_UNIMP_BITS '08C:CF'} // PIE1
+  {$SET_UNIMP_BITS '08D:35'} // PIE2
+  {$SET_UNIMP_BITS '08F:36'} // OSCCON
+  {$SET_UNIMP_BITS '090:F9'} // FVR1CON0
+  {$SET_UNIMP_BITS '091:EC'} // DAC1CON0
+  {$SET_UNIMP_BITS '096:9F'} // OPA1CON
+  {$SET_UNIMP_BITS '09F:03'} // CMOUT
+  {$SET_UNIMP_BITS '105:37'} // LATA
+  {$SET_UNIMP_BITS '107:3F'} // LATC
+  {$SET_UNIMP_BITS '108:3F'} // IOCAN
+  {$SET_UNIMP_BITS '109:3F'} // IOCCN
+  {$SET_UNIMP_BITS '10C:3F'} // WPUA
+  {$SET_UNIMP_BITS '10D:3F'} // WPUC
+  {$SET_UNIMP_BITS '10E:30'} // SLRCONC
+  {$SET_UNIMP_BITS '10F:03'} // PCON
+  {$SET_UNIMP_BITS '111:00'} // PR2
+  {$SET_UNIMP_BITS '112:7B'} // T2CON
+  {$SET_UNIMP_BITS '114:00'} // HLTPR1
+  {$SET_UNIMP_BITS '115:7B'} // HLT1CON0
+  {$SET_UNIMP_BITS '116:DF'} // HLT1CON1
+  {$SET_UNIMP_BITS '119:7F'} // HLT2CON0
+  {$SET_UNIMP_BITS '11A:DF'} // HLT2CON1
+  {$SET_UNIMP_BITS '11E:BD'} // SLPC1CON0
+  {$SET_UNIMP_BITS '11F:1F'} // SLPC1CON1
+  {$SET_UNIMP_BITS '185:17'} // ANSELA
+  {$SET_UNIMP_BITS '187:0F'} // ANSELC
+  {$SET_UNIMP_BITS '188:10'} // APFCON
+  {$SET_UNIMP_BITS '189:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '18C:07'} // PMCON1
+  {$SET_UNIMP_BITS '18F:07'} // PMADRH
+  {$SET_UNIMP_BITS '191:3F'} // PMDATH
+  {$SET_UNIMP_BITS '192:0F'} // COG1PHR
+  {$SET_UNIMP_BITS '193:0F'} // COG1PHF
+  {$SET_UNIMP_BITS '194:0F'} // COG1BKR
+  {$SET_UNIMP_BITS '195:0F'} // COG1BKF
+  {$SET_UNIMP_BITS '196:0F'} // COG1DBR
+  {$SET_UNIMP_BITS '197:0F'} // COG1DBF
+  {$SET_UNIMP_BITS '198:FD'} // COG1CON0
+  {$SET_UNIMP_BITS '199:C3'} // COG1CON1
+  {$SET_UNIMP_BITS '19A:7F'} // COG1RIS
+  {$SET_UNIMP_BITS '19B:7F'} // COG1RSIM
+  {$SET_UNIMP_BITS '19C:7F'} // COG1FIS
+  {$SET_UNIMP_BITS '19D:7F'} // COG1FSIM
+  {$SET_UNIMP_BITS '19E:FC'} // COG1ASD0
+  {$SET_UNIMP_BITS '19F:1F'} // COG1ASD1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/CLKIN
+  // Pin  3 : RA4/T1G/AN3/CLKOUT
+  // Pin  4 : RA3/T1G/Vpp/MCLR
+  // Pin  5 : RC5/COG1OUT0/CCP1
+  // Pin  6 : RC4/COG1OUT1/C2OUT
+  // Pin  7 : RC3/AN7/C1IN3-/C2IN3-
+  // Pin  8 : RC2/SLPCIN/AN6/OPA1OUT/C1IN2-/C2IN2-
+  // Pin  9 : RC1/OPA1IN-/AN5/C1IN1-/C2IN1-
+  // Pin 10 : RC0/OPA1IN+/AN4/C2IN0+
+  // Pin 11 : RA2/INT/C1OUT/T0CKI/AN2/COG1FLT
+  // Pin 12 : RA1/C1IN0-/C2IN0-/AN1/VREF+/FVRIN/ICSPCLK
+  // Pin 13 : RA0/C1IN0+/AN0/DACOUT/FVROUT/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : Debug Mode Enable bit
+  {$define _DEBUG_OFF       = $3F79}  // Debug mode disabled
+  {$define _DEBUG_ON        = $3F78}  // Debug mode enabled
+
+  // CLKOUTEN : Clock Out Enable bit
+  {$define _CLKOUTEN_OFF    = $3F7B}  // CLKOUT function disabled.  CLKOUT pin acts as I/O
+  {$define _CLKOUTEN_ON     = $3F79}  // CLKOUT function enabled.  CLKOUT pin is CLKOUT
+
+  // WRT : Flash Program Memory Self Write Enable bit
+  {$define _WRT_OFF         = $3F7D}  // Flash self-write protection off
+  {$define _WRT_FOURTH      = $3F79}  // 000h to 0FFh self-write protected
+  {$define _WRT_HALF        = $3F75}  // 000h to 1FFh self-write protected
+  {$define _WRT_ALL         = $3F71}  // 000h to 3FFh self-write protected
+
+  // BOREN : Brown-out Reset Enable bits
+  {$define _BOREN_EN        = $3F79}  // BOR enabled
+  {$define _BOREN_SLEEP_DIS = $3F69}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_DIS       = $3F49}  // BOR disabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF          = $3F79}  // Program memory code protection is disabled
+  {$define _CP_ON           = $3F39}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON        = $3FF9}  // MCLR pin is MCLR function with internal weak pullup
+  {$define _MCLRE_OFF       = $3F79}  // MCLR pin is alternate function
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF       = $3F79}  // Power-up Timer disabled
+  {$define _PWRTE_ON        = $3E79}  // Power-up Timer enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON         = $3F79}  // Watchdog Timer enabled
+  {$define _WDTE_OFF        = $3D79}  // Watchdog Timer disabled
+
+  // FOSC0 : FOSC: Oscillator Selection bit
+  {$define _FOSC0_EC        = $3F79}  // EC oscillator mode.  CLKIN function on RA5/CLKIN
+  {$define _FOSC0_INT       = $3B79}  // Internal oscillator mode.  I/O function on RA5/CLKIN
+
+implementation
+end.

--- a/PIC16F76.pas
+++ b/PIC16F76.pas
@@ -1,0 +1,337 @@
+unit PIC16F76;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F76'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_CCP2IF       : bit  absolute PIR2.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_FERR        : bit  absolute RCSTA.3;
+  RCSTA_OERR        : bit  absolute RCSTA.2;
+  RCSTA_RX9D        : bit  absolute RCSTA.1;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_CCP2IE       : bit  absolute PIE2.0;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON1            : byte absolute $009f;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-01F:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08E:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '018:F7'} // RCSTA
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:07'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:81'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKI
+  // Pin 10 : OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/PGM
+  // Pin 25 : RB4
+  // Pin 26 : RB5
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON  = $005F}  // BOR enabled
+  {$define _BOREN_OFF = $005E}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bit
+  {$define _CP_OFF    = $005F}  // Code protection off
+  {$define _CP_ON     = $005D}  // All Memory locations code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF = $005F}  // PWRT disabled
+  {$define _PWRTE_ON  = $005B}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON   = $005F}  // WDT enabled
+  {$define _WDTE_OFF  = $0057}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_RC   = $007F}  // RC oscillator
+  {$define _FOSC_HS   = $006F}  // HS oscillator
+  {$define _FOSC_XT   = $005F}  // XT oscillator
+  {$define _FOSC_LP   = $004F}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F767.pas
+++ b/PIC16F767.pas
@@ -1,0 +1,465 @@
+unit PIC16F767;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F767'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_LVDIF        : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP3IF       : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1RUN       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_CHS3       : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_LVDIE        : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP3IE       : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.2;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.5;
+  OSCCON_IRCF1      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCCON_SCS0       : bit  absolute OSCCON.1;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  CCPR3L            : byte absolute $0095;
+  CCPR3H            : byte absolute $0096;
+  CCP3CON           : byte absolute $0097;
+  CCP3CON_CCP3X     : bit  absolute CCP3CON.5;
+  CCP3CON_CCP3Y     : bit  absolute CCP3CON.4;
+  CCP3CON_CCP3M3    : bit  absolute CCP3CON.3;
+  CCP3CON_CCP3M2    : bit  absolute CCP3CON.2;
+  CCP3CON_CCP3M1    : bit  absolute CCP3CON.1;
+  CCP3CON_CCP3M0    : bit  absolute CCP3CON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON2            : byte absolute $009b;
+  ADCON2_ACQT2      : bit  absolute ADCON2.5;
+  ADCON2_ACQT1      : bit  absolute ADCON2.4;
+  ADCON2_ACQT0      : bit  absolute ADCON2.3;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL3      : bit  absolute LVDCON.3;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-099:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPADD, SSPSTAT, CCPR3L, CCPR3H, CCP3CON, TXSTA, SPBRG
+  {$SET_STATE_RAM '09B-09F:SFR'}  // ADCON2, CMCON, CVRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-106:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB
+  {$SET_STATE_RAM '109-10F:SFR'}  // LVDCON, PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:EB'} // PIR2
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:EB'} // PIE2
+  {$SET_UNIMP_BITS '08E:07'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '097:3F'} // CCP3CON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09B:38'} // ADCON2
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:3F'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp/RE3
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-/CVref
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/LVDIN/SS/C2OUT
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKI/RA7
+  // Pin 10 : OSC2/CLKO/RA6
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT/AN12
+  // Pin 22 : RB1/AN10
+  // Pin 23 : RB2/AN8
+  // Pin 24 : RB3/CCP2/AN9
+  // Pin 25 : RB4/AN11
+  // Pin 26 : RB5/AN13/CCP3
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bits
+  {$define _CP_OFF         = $39FF}  // Code protection off
+  {$define _CP_ON          = $39FE}  // 0000h to 1FFFh code-protected
+
+  // CCP2MX : CCP2 Multiplex bit
+  {$define _CCP2MX_RC1     = $39FF}  // CCP2 is on RC1
+  {$define _CCP2MX_RB3     = $39FD}  // CCP2 is on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $39FF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $39FB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // BORV : Brown-out Reset Voltage bits
+  {$define _BORV_20        = $39FF}  // VBOR set to 2.0V
+  {$define _BORV_27        = $39F7}  // VBOR set to 2.7V
+  {$define _BORV_42        = $39EF}  // VBOR set to 4.2V
+  {$define _BORV_45        = $39E7}  // VBOR set to 4.5V
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $39FF}  // Enabled
+  {$define _BOREN_OFF      = $39DF}  // Disabled
+
+  // MCLRE : MCLR/VPP/RE3 Pin Function Select bit
+  {$define _MCLRE_ON       = $39FF}  // MCLR/VPP/RE3 pin function is MCLR
+  {$define _MCLRE_OFF      = $39BF}  // MCLR/VPP/RE3 pin function is digital input only, MCLR gated to '1'
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $39FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $397F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $39FF}  // WDT enabled
+  {$define _WDTE_OFF       = $38FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $27FF}  // EXTRC oscillator; CLKO function on OSC2/CLKO/RA6
+  {$define _FOSC_EXTRCIO   = $25FF}  // EXTRC oscillator; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_INTOSCCLK = $23FF}  // INTRC oscillator; CLKO function on OSC2/CLKO/RA6 and port I/O function on OSC1/CLKI/RA7
+  {$define _FOSC_INTOSCIO  = $21FF}  // INTRC oscillator; port I/O function on OSC1/CLKI/RA7 and OSC2/CLKO/RA6
+  {$define _FOSC_EC        = $07FF}  // EXTCLK; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_HS        = $05FF}  // HS oscillator
+  {$define _FOSC_XT        = $03FF}  // XT oscillator
+  {$define _FOSC_LP        = $01FF}  // LP oscillator
+
+  // BORSEN : Brown-out Reset Software Enable bit
+  {$define _BORSEN_ON      = $0043}  // Enabled
+  {$define _BORSEN_OFF     = $0042}  // Disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0043}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $0041}  // Internal External Switchover mode disabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $0047}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $0043}  // Fail-Safe Clock Monitor disabled
+
+implementation
+end.

--- a/PIC16F77.pas
+++ b/PIC16F77.pas
@@ -1,0 +1,381 @@
+unit PIC16F77;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F77'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_CCP2IF       : bit  absolute PIR2.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_FERR        : bit  absolute RCSTA.3;
+  RCSTA_OERR        : bit  absolute RCSTA.2;
+  RCSTA_RX9D        : bit  absolute RCSTA.1;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRES             : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE2      : bit  absolute TRISE.3;
+  TRISE_TRISE1      : bit  absolute TRISE.2;
+  TRISE_TRISE0      : bit  absolute TRISE.1;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_CCP2IE       : bit  absolute PIE2.0;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON1            : byte absolute $009f;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRES, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-08E:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09F-09F:SFR'}  // ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '009:07'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:01'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '018:F7'} // RCSTA
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '089:F7'} // TRISE
+  {$SET_UNIMP_BITS '08D:01'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:07'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:81'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2
+  // Pin  5 : RA3/AN3/Vref
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKI
+  // Pin 14 : OSC2/CLKO
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT
+  // Pin 34 : RB1
+  // Pin 35 : RB2
+  // Pin 36 : RB3/PGM
+  // Pin 37 : RB4
+  // Pin 38 : RB5
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON  = $005F}  // BOR enabled
+  {$define _BOREN_OFF = $005E}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bit
+  {$define _CP_OFF    = $005F}  // Code protection off
+  {$define _CP_ON     = $005D}  // All Memory locations code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF = $005F}  // PWRT disabled
+  {$define _PWRTE_ON  = $005B}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON   = $005F}  // WDT enabled
+  {$define _WDTE_OFF  = $0057}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_RC   = $007F}  // RC oscillator
+  {$define _FOSC_HS   = $006F}  // HS oscillator
+  {$define _FOSC_XT   = $005F}  // XT oscillator
+  {$define _FOSC_LP   = $004F}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F777.pas
+++ b/PIC16F777.pas
@@ -1,0 +1,504 @@
+unit PIC16F777;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F777'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_LVDIF        : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP3IF       : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1RUN       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_CHS3       : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_LVDIE        : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP3IE       : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.2;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.5;
+  OSCCON_IRCF1      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCCON_SCS0       : bit  absolute OSCCON.1;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  CCPR3L            : byte absolute $0095;
+  CCPR3H            : byte absolute $0096;
+  CCP3CON           : byte absolute $0097;
+  CCP3CON_CCP3X     : bit  absolute CCP3CON.5;
+  CCP3CON_CCP3Y     : bit  absolute CCP3CON.4;
+  CCP3CON_CCP3M3    : bit  absolute CCP3CON.3;
+  CCP3CON_CCP3M2    : bit  absolute CCP3CON.2;
+  CCP3CON_CCP3M1    : bit  absolute CCP3CON.1;
+  CCP3CON_CCP3M0    : bit  absolute CCP3CON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADCON2            : byte absolute $009b;
+  ADCON2_ACQT2      : bit  absolute ADCON2.5;
+  ADCON2_ACQT1      : bit  absolute ADCON2.4;
+  ADCON2_ACQT0      : bit  absolute ADCON2.3;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL3      : bit  absolute LVDCON.3;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  PMDATA            : byte absolute $010c;
+  PMADR             : byte absolute $010d;
+  PMDATH            : byte absolute $010e;
+  PMADRH            : byte absolute $010f;
+  PMCON1            : byte absolute $018c;
+  PMCON1_RD         : bit  absolute PMCON1.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-099:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPADD, SSPSTAT, CCPR3L, CCPR3H, CCP3CON, TXSTA, SPBRG
+  {$SET_STATE_RAM '09B-09F:SFR'}  // ADCON2, CMCON, CVRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-106:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB
+  {$SET_STATE_RAM '109-10F:SFR'}  // LVDCON, PCLATH, INTCON, PMDATA, PMADR, PMDATH, PMADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18C:SFR'}  // PCLATH, INTCON, PMCON1
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:EB'} // PIR2
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '08D:EB'} // PIE2
+  {$SET_UNIMP_BITS '08E:07'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '097:3F'} // CCP3CON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09B:38'} // ADCON2
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:3F'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // PMDATH
+  {$SET_UNIMP_BITS '10F:1F'} // PMADRH
+  {$SET_UNIMP_BITS '18C:01'} // PMCON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp/RE3
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-/CVref
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/LVDIN/SS/C2OUT
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKI/RA7
+  // Pin 14 : OSC2/CLKO/RA6
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT/AN12
+  // Pin 34 : RB1/AN10
+  // Pin 35 : RB2/AN8
+  // Pin 36 : RB3/CCP2/AN9
+  // Pin 37 : RB4/AN11
+  // Pin 38 : RB5/AN13/CCP3
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bits
+  {$define _CP_OFF         = $39FF}  // Code protection off
+  {$define _CP_ON          = $39FE}  // 0000h to 1FFFh code-protected
+
+  // CCP2MX : CCP2 Multiplex bit
+  {$define _CCP2MX_RC1     = $39FF}  // CCP2 is on RC1
+  {$define _CCP2MX_RB3     = $39FD}  // CCP2 is on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $39FF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $39FB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // BORV : Brown-out Reset Voltage bits
+  {$define _BORV_20        = $39FF}  // VBOR set to 2.0V
+  {$define _BORV_27        = $39F7}  // VBOR set to 2.7V
+  {$define _BORV_42        = $39EF}  // VBOR set to 4.2V
+  {$define _BORV_45        = $39E7}  // VBOR set to 4.5V
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $39FF}  // Enabled
+  {$define _BOREN_OFF      = $39DF}  // Disabled
+
+  // MCLRE : MCLR/VPP/RE3 Pin Function Select bit
+  {$define _MCLRE_ON       = $39FF}  // MCLR/VPP/RE3 pin function is MCLR
+  {$define _MCLRE_OFF      = $39BF}  // MCLR/VPP/RE3 pin function is digital input only, MCLR gated to '1'
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $39FF}  // PWRT disabled
+  {$define _PWRTE_ON       = $397F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $39FF}  // WDT enabled
+  {$define _WDTE_OFF       = $38FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $27FF}  // EXTRC oscillator; CLKO function on OSC2/CLKO/RA6
+  {$define _FOSC_EXTRCIO   = $25FF}  // EXTRC oscillator; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_INTOSCCLK = $23FF}  // INTRC oscillator; CLKO function on OSC2/CLKO/RA6 and port I/O function on OSC1/CLKI/RA7
+  {$define _FOSC_INTOSCIO  = $21FF}  // INTRC oscillator; port I/O function on OSC1/CLKI/RA7 and OSC2/CLKO/RA6
+  {$define _FOSC_EC        = $07FF}  // EXTCLK; port I/O function on OSC2/CLKO/RA6
+  {$define _FOSC_HS        = $05FF}  // HS oscillator
+  {$define _FOSC_XT        = $03FF}  // XT oscillator
+  {$define _FOSC_LP        = $01FF}  // LP oscillator
+
+  // BORSEN : Brown-out Reset Software Enable bit
+  {$define _BORSEN_ON      = $0043}  // Enabled
+  {$define _BORSEN_OFF     = $0042}  // Disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0043}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $0041}  // Internal External Switchover mode disabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $0047}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $0043}  // Fail-Safe Clock Monitor disabled
+
+implementation
+end.

--- a/PIC16F785.pas
+++ b/PIC16F785.pas
@@ -1,0 +1,431 @@
+unit PIC16F785;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F785'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RAIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RAIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_CCP1IF       : bit  absolute PIR1.5;
+  PIR1_C2IF         : bit  absolute PIR1.4;
+  PIR1_C1IF         : bit  absolute PIR1.3;
+  PIR1_OSFIF        : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0013;
+  CCPR1H            : byte absolute $0014;
+  CCP1CON           : byte absolute $0015;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  WDTCON            : byte absolute $0018;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG       : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RAPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_CCP1IE       : bit  absolute PIE1.5;
+  PIE1_C2IE         : bit  absolute PIE1.4;
+  PIE1_C1IE         : bit  absolute PIE1.3;
+  PIE1_OSFIE        : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL0            : byte absolute $0091;
+  ANSEL0_ANS7       : bit  absolute ANSEL0.7;
+  ANSEL0_ANS6       : bit  absolute ANSEL0.6;
+  ANSEL0_ANS5       : bit  absolute ANSEL0.5;
+  ANSEL0_ANS4       : bit  absolute ANSEL0.4;
+  ANSEL0_ANS3       : bit  absolute ANSEL0.3;
+  ANSEL0_ANS2       : bit  absolute ANSEL0.2;
+  ANSEL0_ANS1       : bit  absolute ANSEL0.1;
+  ANSEL0_ANS0       : bit  absolute ANSEL0.0;
+  PR2               : byte absolute $0092;
+  ANSEL1            : byte absolute $0093;
+  ANSEL1_ANS11      : bit  absolute ANSEL1.3;
+  ANSEL1_ANS10      : bit  absolute ANSEL1.2;
+  ANSEL1_ANS9       : bit  absolute ANSEL1.1;
+  ANSEL1_ANS8       : bit  absolute ANSEL1.0;
+  WPUA              : byte absolute $0095;
+  WPUA_WPUA5        : bit  absolute WPUA.5;
+  WPUA_WPUA4        : bit  absolute WPUA.4;
+  WPUA_WPUA3        : bit  absolute WPUA.3;
+  WPUA_WPUA2        : bit  absolute WPUA.2;
+  WPUA_WPUA1        : bit  absolute WPUA.1;
+  WPUA_WPUA0        : bit  absolute WPUA.0;
+  IOCA              : byte absolute $0096;
+  IOCA_IOCA5        : bit  absolute IOCA.5;
+  IOCA_IOCA4        : bit  absolute IOCA.4;
+  IOCA_IOCA3        : bit  absolute IOCA.3;
+  IOCA_IOCA2        : bit  absolute IOCA.2;
+  IOCA_IOCA1        : bit  absolute IOCA.1;
+  IOCA_IOCA0        : bit  absolute IOCA.0;
+  REFCON            : byte absolute $0098;
+  REFCON_BGST       : bit  absolute REFCON.5;
+  REFCON_VRBB       : bit  absolute REFCON.4;
+  REFCON_VREN       : bit  absolute REFCON.3;
+  REFCON_VROE       : bit  absolute REFCON.2;
+  REFCON_CVROE      : bit  absolute REFCON.1;
+  VRCON             : byte absolute $0099;
+  VRCON_C1VREN      : bit  absolute VRCON.7;
+  VRCON_C2VREN      : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.4;
+  VRCON_VR2         : bit  absolute VRCON.3;
+  VRCON_VR1         : bit  absolute VRCON.2;
+  VRCON_VR0         : bit  absolute VRCON.1;
+  EEDATA            : byte absolute $009a;
+  EEADR             : byte absolute $009b;
+  EECON1            : byte absolute $009c;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $009d;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  PWMCON1           : byte absolute $0110;
+  PWMCON1_OVRLP     : bit  absolute PWMCON1.7;
+  PWMCON1_COMOD1    : bit  absolute PWMCON1.6;
+  PWMCON1_COMOD0    : bit  absolute PWMCON1.5;
+  PWMCON1_CMDLY4    : bit  absolute PWMCON1.4;
+  PWMCON1_CMDLY3    : bit  absolute PWMCON1.3;
+  PWMCON1_CMDLY2    : bit  absolute PWMCON1.2;
+  PWMCON1_CMDLY1    : bit  absolute PWMCON1.1;
+  PWMCON1_CMDLY0    : bit  absolute PWMCON1.0;
+  PWMCON0           : byte absolute $0111;
+  PWMCON0_PRSEN     : bit  absolute PWMCON0.7;
+  PWMCON0_PASEN     : bit  absolute PWMCON0.6;
+  PWMCON0_BLANK2    : bit  absolute PWMCON0.5;
+  PWMCON0_BLANK1    : bit  absolute PWMCON0.4;
+  PWMCON0_SYNC1     : bit  absolute PWMCON0.3;
+  PWMCON0_SYNC0     : bit  absolute PWMCON0.2;
+  PWMCON0_PH2EN     : bit  absolute PWMCON0.1;
+  PWMCON0_PH1EN     : bit  absolute PWMCON0.0;
+  PWMCLK            : byte absolute $0112;
+  PWMCLK_PWMASE     : bit  absolute PWMCLK.7;
+  PWMCLK_PWMP1      : bit  absolute PWMCLK.6;
+  PWMCLK_PWMP0      : bit  absolute PWMCLK.5;
+  PWMCLK_PER4       : bit  absolute PWMCLK.4;
+  PWMCLK_PER3       : bit  absolute PWMCLK.3;
+  PWMCLK_PER2       : bit  absolute PWMCLK.2;
+  PWMCLK_PER1       : bit  absolute PWMCLK.1;
+  PWMCLK_PER0       : bit  absolute PWMCLK.0;
+  PWMPH1            : byte absolute $0113;
+  PWMPH1_POL        : bit  absolute PWMPH1.7;
+  PWMPH1_C2EN       : bit  absolute PWMPH1.6;
+  PWMPH1_C1EN       : bit  absolute PWMPH1.5;
+  PWMPH1_PH4        : bit  absolute PWMPH1.4;
+  PWMPH1_PH3        : bit  absolute PWMPH1.3;
+  PWMPH1_PH2        : bit  absolute PWMPH1.2;
+  PWMPH1_PH1        : bit  absolute PWMPH1.1;
+  PWMPH1_PH0        : bit  absolute PWMPH1.0;
+  PWMPH2            : byte absolute $0114;
+  CM1CON0           : byte absolute $0119;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1SP      : bit  absolute CM1CON0.3;
+  CM1CON0_C1R       : bit  absolute CM1CON0.2;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $011a;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2SP      : bit  absolute CM2CON0.3;
+  CM2CON0_C2R       : bit  absolute CM2CON0.2;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $011b;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.5;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.4;
+  OPA1CON           : byte absolute $011c;
+  OPA1CON_OPAON     : bit  absolute OPA1CON.7;
+  OPA2CON           : byte absolute $011d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-00C:SFR'}  // PCLATH, INTCON, PIR1
+  {$SET_STATE_RAM '00E-015:SFR'}  // TMR1L, TMR1H, T1CON, TMR2, T2CON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '018-018:SFR'}  // WDTCON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08C:SFR'}  // PCLATH, INTCON, PIE1
+  {$SET_STATE_RAM '08E-093:SFR'}  // PCON, OSCCON, OSCTUNE, ANSEL0, PR2, ANSEL1
+  {$SET_STATE_RAM '095-096:SFR'}  // WPUA, IOCA
+  {$SET_STATE_RAM '098-09F:SFR'}  // REFCON, VRCON, EEDATA, EEADR, EECON1, EECON2, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-107:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '10A-10B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '110-114:SFR'}  // PWMCON1, PWMCON0, PWMCLK, PWMPH1, PWMPH2
+  {$SET_STATE_RAM '119-11D:SFR'}  // CM1CON0, CM2CON0, CM2CON1, OPA1CON, OPA2CON
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-187:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '18A-18B:SFR'}  // PCLATH, INTCON
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-107:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '185-187:bnk1'} // TRISA, TRISB, TRISC
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '006:F0'} // PORTB
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '015:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '018:1F'} // WDTCON
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '086:F0'} // TRISB
+  {$SET_UNIMP_BITS '08E:13'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:0F'} // ANSEL1
+  {$SET_UNIMP_BITS '095:3F'} // WPUA
+  {$SET_UNIMP_BITS '096:3F'} // IOCA
+  {$SET_UNIMP_BITS '098:3E'} // REFCON
+  {$SET_UNIMP_BITS '099:EF'} // VRCON
+  {$SET_UNIMP_BITS '09C:0F'} // EECON1
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '11B:C3'} // CM2CON1
+  {$SET_UNIMP_BITS '11C:80'} // OPA1CON
+  {$SET_UNIMP_BITS '11D:80'} // OPA2CON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RA5/T1CKI/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/T1G/OSC2/CLKOUT
+  // Pin  4 : RA3/MCLR/Vpp
+  // Pin  5 : RC5/CCP1
+  // Pin  6 : RC4/C2OUT/PH2
+  // Pin  7 : RC3/AN7/C12IN3-/OP1
+  // Pin  8 : RC6/AN8/OP1-
+  // Pin  9 : RC7/AN9/OP1+
+  // Pin 10 : RB7/SYNC
+  // Pin 11 : RB6
+  // Pin 12 : RB5/AN11/OP2+
+  // Pin 13 : RB4/AN10/OP2-
+  // Pin 14 : RC2/AN6/C12IN2-/OP2
+  // Pin 15 : RC1/AN5/C12IN1-/PH1
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/T0CKI/INT/C1OUT
+  // Pin 18 : RA1/AN1/C12IN0-/Vref/ICSPCLK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT
+  // Pin 20 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '006:4-13,5-12,6-11,7-10'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $0FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $0FFE}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0FFF}  // Internal External Switchover mode is enabled
+  {$define _IESO_OFF       = $0FFD}  // Internal External Switchover mode is disabled
+
+  // BOREN : Brown Out Detect
+  {$define _BOREN_ON       = $0FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $0FFB}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $0FF7}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $0FF3}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $0FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $0FEF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $0FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $0FDF}  // Program memory code protection is enabled
+
+  // MCLRE : MCLR Pin Function Select bit
+  {$define _MCLRE_ON       = $0FFF}  // MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $0FBF}  // MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $0FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $0F7F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $0FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $0EFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $0FFF}  // EXTRC oscillator: External RC on RA5/OSC1/CLKIN, CLKOUT function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_EXTRCIO   = $0DFF}  // EXTRCIO oscillator: External RC on RA5/OSC1/CLKIN, I/O function on RA4/OSC2/CLKOUT pin
+  {$define _FOSC_INTOSCCLK = $0BFF}  // INTOSC oscillator: CLKOUT function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_INTOSCIO  = $09FF}  // INTOSCIO oscillator: I/O function on RA4/OSC2/CLKOUT pin, I/O function on RA5/OSC1/CLKIN
+  {$define _FOSC_EC        = $07FF}  // EC: I/O function on RA4/OSC2/CLKOUT pin, CLKIN on RA5/OSC1/CLKIN
+  {$define _FOSC_HS        = $05FF}  // HS oscillator: High-speed crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+  {$define _FOSC_XT        = $03FF}  // XT oscillator: Crystal/resonator on RA4/OSC2/CLKOUT and RA5/OSC1/CLKINT
+  {$define _FOSC_LP        = $01FF}  // LP oscillator: Low-power crystal on RA4/OSC2/CLKOUT and RA5/OSC1/CLKIN
+
+implementation
+end.

--- a/PIC16F818.pas
+++ b/PIC16F818.pas
@@ -1,0 +1,329 @@
+unit PIC16F818;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F818'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_SSPIF        : bit  absolute PIR1.5;
+  PIR1_CCP1IF       : bit  absolute PIR1.4;
+  PIR1_TMR2IF       : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_SSPIE        : bit  absolute PIE1.5;
+  PIE1_CCP1IE       : bit  absolute PIE1.4;
+  PIE1_TMR2IE       : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_FREE       : bit  absolute EECON1.6;
+  EECON1_WRERR      : bit  absolute EECON1.5;
+  EECON1_WREN       : bit  absolute EECON1.4;
+  EECON1_WR         : bit  absolute EECON1.3;
+  EECON1_RD         : bit  absolute EECON1.2;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-017:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:4F'} // PIR1
+  {$SET_UNIMP_BITS '00D:10'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '08C:4F'} // PIE1
+  {$SET_UNIMP_BITS '08D:10'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '08F:74'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '09F:CF'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:07'} // EEADRH
+  {$SET_UNIMP_BITS '18C:9F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref-
+  // Pin  2 : RA3/AN3/Vref+
+  // Pin  3 : RA4/AN4/T0CKI
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/SDI/SDA
+  // Pin  8 : RB2/SDO/CCP1
+  // Pin  9 : RB3/CCP1/PGM
+  // Pin 10 : RB4/SCK/SCL
+  // Pin 11 : RB5/SS
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKO
+  // Pin 16 : RA7/OSC1/CLKI
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Code protection off
+  {$define _CP_ON          = $3FFE}  // All memory locations code-protected
+
+  // CCPMX : CCP1 Pin Selection bit
+  {$define _CCPMX_RB2      = $3FFF}  // CCP1 function on RB2
+  {$define _CCPMX_RB3      = $3FFD}  // CCP1 function on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3FFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $3FFB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : Flash Program Memory Write Enable bits
+  {$define _WRT_OFF        = $3FFF}  // Write protection off
+  {$define _WRT_512        = $3FF7}  // 0000h to 01FFh write-protected, 0200h to 03FFh may be modified by EECON control
+  {$define _WRT_1024       = $3FEF}  // 0000h to 03FFh write-protected
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $3FFF}  // Code protection off
+  {$define _CPD_ON         = $3FDF}  // Data EE memory locations code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $3FFF}  // RB3/PGM pin has PGM function, Low-Voltage Programming enabled
+  {$define _LVP_OFF        = $3FBF}  // RB3/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $3FFF}  // BOR enabled
+  {$define _BOREN_OFF      = $3F7F}  // BOR disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $3FFF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $3EFF}  // RA5/MCLR/VPP pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $9FFF}  // EXTRC oscillator; CLKO function on RA6/OSC2/CLKO pin
+  {$define _FOSC_EXTRCIO   = $97FF}  // EXTRC oscillator; port I/O function on RA6/OSC2/CLKO pin
+  {$define _FOSC_INTOSCCLK = $8FFF}  // INTRC oscillator; CLKO function on RA6/OSC2/CLKO pin and port I/O function on RA7/OSC1/CLKI pin
+  {$define _FOSC_INTOSCIO  = $87FF}  // INTRC oscillator; port I/O function on both RA6/OSC2/CLKO pin and RA7/OSC1/CLKI pin
+  {$define _FOSC_EC        = $1FFF}  // EXTCLK; port I/O function on RA6/OSC2/CLKO pin
+  {$define _FOSC_HS        = $17FF}  // HS oscillator
+  {$define _FOSC_XT        = $0FFF}  // XT oscillator
+  {$define _FOSC_LP        = $07FF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F819.pas
+++ b/PIC16F819.pas
@@ -1,0 +1,330 @@
+unit PIC16F819;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F819'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_SSPIF        : bit  absolute PIR1.5;
+  PIR1_CCP1IF       : bit  absolute PIR1.4;
+  PIR1_TMR2IF       : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_SSPIE        : bit  absolute PIE1.5;
+  PIE1_CCP1IE       : bit  absolute PIE1.4;
+  PIE1_TMR2IE       : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_FREE       : bit  absolute EECON1.6;
+  EECON1_WRERR      : bit  absolute EECON1.5;
+  EECON1_WREN       : bit  absolute EECON1.4;
+  EECON1_WR         : bit  absolute EECON1.3;
+  EECON1_RD         : bit  absolute EECON1.2;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-017:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:4F'} // PIR1
+  {$SET_UNIMP_BITS '00D:10'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '08C:4F'} // PIE1
+  {$SET_UNIMP_BITS '08D:10'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '08F:74'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '09F:CF'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:07'} // EEADRH
+  {$SET_UNIMP_BITS '18C:9F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/Vref-
+  // Pin  2 : RA3/AN3/Vref+
+  // Pin  3 : RA4/AN4/T0CKI
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1/SDI/SDA
+  // Pin  8 : RB2/SDO/CCP1
+  // Pin  9 : RB3/CCP1/PGM
+  // Pin 10 : RB4/SCK/SCL
+  // Pin 11 : RB5/SS
+  // Pin 12 : RB6/T1OSO/T1CKI/PGC
+  // Pin 13 : RB7/T1OSI/PGD
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKO
+  // Pin 16 : RA7/OSC1/CLKI
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Code protection off
+  {$define _CP_ON          = $3FFE}  // All memory locations code-protected
+
+  // CCPMX : CCP1 Pin Selection bit
+  {$define _CCPMX_RB2      = $3FFF}  // CCP1 function on RB2
+  {$define _CCPMX_RB3      = $3FFD}  // CCP1 function on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3FFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $3FFB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : Flash Program Memory Write Enable bits
+  {$define _WRT_OFF        = $3FFF}  // Write protection off
+  {$define _WRT_512        = $3FF7}  // 0000h to 01FFh write-protected, 0200h to 07FFh may be modified by EECON control
+  {$define _WRT_1024       = $3FEF}  // 0000h to 03FFh write-protected, 0400h to 07FFh may be modified by EECON control
+  {$define _WRT_1536       = $3FE7}  // 0000h to 05FFh write-protected, 0600h to 07FFh may be modified by EECON control
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $3FFF}  // Code protection off
+  {$define _CPD_ON         = $3FDF}  // Data EE memory locations code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $3FFF}  // RB3/PGM pin has PGM function, Low-Voltage Programming enabled
+  {$define _LVP_OFF        = $3FBF}  // RB3/PGM pin has digital I/O function, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $3FFF}  // BOR enabled
+  {$define _BOREN_OFF      = $3F7F}  // BOR disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $3FFF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $3EFF}  // RA5/MCLR/VPP pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $9FFF}  // EXTRC oscillator; CLKO function on RA6/OSC2/CLKO pin
+  {$define _FOSC_EXTRCIO   = $97FF}  // EXTRC oscillator; port I/O function on RA6/OSC2/CLKO pin
+  {$define _FOSC_INTOSCCLK = $8FFF}  // INTRC oscillator; CLKO function on RA6/OSC2/CLKO pin and port I/O function on RA7/OSC1/CLKI pin
+  {$define _FOSC_INTOSCIO  = $87FF}  // INTRC oscillator; port I/O function on both RA6/OSC2/CLKO pin and RA7/OSC1/CLKI pin
+  {$define _FOSC_EC        = $1FFF}  // EXTCLK; port I/O function on RA6/OSC2/CLKO pin
+  {$define _FOSC_HS        = $17FF}  // HS oscillator
+  {$define _FOSC_XT        = $0FFF}  // XT oscillator
+  {$define _FOSC_LP        = $07FF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F83.pas
+++ b/PIC16F83.pas
@@ -1,0 +1,161 @@
+unit PIC16F83;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F83'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  EEDATA            : byte absolute $0008;
+  EEADR             : byte absolute $0009;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_EEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  EECON1            : byte absolute $0088;
+  EECON1_EEIF       : bit  absolute EECON1.4;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $0089;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '008-00B:SFR'}  // EEDATA, EEADR, PCLATH, INTCON
+  {$SET_STATE_RAM '00C-02F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '088-08B:SFR'}  // EECON1, EECON2, PCLATH, INTCON
+  {$SET_STATE_RAM '08C-0AF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:1F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '085:1F'} // TRISA
+  {$SET_UNIMP_BITS '088:1F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2
+  // Pin  2 : RA3
+  // Pin  3 : RA4/T0CKI
+  // Pin  4 : MCLR
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1
+  // Pin  8 : RB2
+  // Pin  9 : RB3
+  // Pin 10 : RB4
+  // Pin 11 : RB5
+  // Pin 12 : RB6
+  // Pin 13 : RB7
+  // Pin 14 : Vdd
+  // Pin 15 : OSC2/CLKOUT
+  // Pin 16 : OSC1/CLKIN
+  // Pin 17 : RA0
+  // Pin 18 : RA1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Code Protection bit
+  {$define _CP_OFF     = $3FFF}  // Code protection disabled
+  {$define _CP_ON      = $3C00}  // All program memory is code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF  = $3FFF}  // Power-up Timer is disabled
+  {$define _PWRTE_ON   = $3BFF}  // Power-up Timer is enabled
+
+  // WDTE : Watchdog Timer
+  {$define _WDTE_ON    = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF   = $37FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC = $3FFF}  // RC oscillator
+  {$define _FOSC_HS    = $2FFF}  // HS oscillator
+  {$define _FOSC_XT    = $1FFF}  // XT oscillator
+  {$define _FOSC_LP    = $0FFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F84.pas
+++ b/PIC16F84.pas
@@ -1,0 +1,161 @@
+unit PIC16F84;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F84'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  EEDATA            : byte absolute $0008;
+  EEADR             : byte absolute $0009;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_EEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  EECON1            : byte absolute $0088;
+  EECON1_EEIF       : bit  absolute EECON1.4;
+  EECON1_WRERR      : bit  absolute EECON1.3;
+  EECON1_WREN       : bit  absolute EECON1.2;
+  EECON1_WR         : bit  absolute EECON1.1;
+  EECON1_RD         : bit  absolute EECON1.0;
+  EECON2            : byte absolute $0089;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '008-00B:SFR'}  // EEDATA, EEADR, PCLATH, INTCON
+  {$SET_STATE_RAM '00C-04F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '088-08B:SFR'}  // EECON1, EECON2, PCLATH, INTCON
+  {$SET_STATE_RAM '08C-0CF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:1F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '085:1F'} // TRISA
+  {$SET_UNIMP_BITS '088:1F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2
+  // Pin  2 : RA3
+  // Pin  3 : RA4/T0CKI
+  // Pin  4 : MCLR
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT
+  // Pin  7 : RB1
+  // Pin  8 : RB2
+  // Pin  9 : RB3
+  // Pin 10 : RB4
+  // Pin 11 : RB5
+  // Pin 12 : RB6
+  // Pin 13 : RB7
+  // Pin 14 : Vdd
+  // Pin 15 : OSC2/CLKOUT
+  // Pin 16 : OSC1/CLKIN
+  // Pin 17 : RA0
+  // Pin 18 : RA1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Code Protection bit
+  {$define _CP_OFF     = $3FFF}  // Code protection disabled
+  {$define _CP_ON      = $3C00}  // All program memory is code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF  = $3FFF}  // Power-up Timer is disabled
+  {$define _PWRTE_ON   = $3BFF}  // Power-up Timer is enabled
+
+  // WDTE : Watchdog Timer
+  {$define _WDTE_ON    = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF   = $37FF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC = $3FFF}  // RC oscillator
+  {$define _FOSC_HS    = $2FFF}  // HS oscillator
+  {$define _FOSC_XT    = $1FFF}  // XT oscillator
+  {$define _FOSC_LP    = $0FFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F87.pas
+++ b/PIC16F87.pas
@@ -1,0 +1,371 @@
+unit PIC16F87;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F87'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INT0IE     : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INT0IF     : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1RUN       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_FREE       : bit  absolute EECON1.6;
+  EECON1_WRERR      : bit  absolute EECON1.5;
+  EECON1_WREN       : bit  absolute EECON1.4;
+  EECON1_WR         : bit  absolute EECON1.3;
+  EECON1_RD         : bit  absolute EECON1.2;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-01A:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09D:SFR'}  // CMCON, CVRCON
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-106:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:3F'} // PIR1
+  {$SET_UNIMP_BITS '00D:D0'} // PIR2
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '08C:3F'} // PIE1
+  {$SET_UNIMP_BITS '08D:D0'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:0F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:9F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/CVref/Vref-
+  // Pin  2 : RA3/AN3/Vref+/C1OUT
+  // Pin  3 : RA4/AN4/T0CKI/C2OUT
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT/CCP1
+  // Pin  7 : RB1/SDI/SDA
+  // Pin  8 : RB2/SDO/RX/DT
+  // Pin  9 : RB3/PGM/CCP1
+  // Pin 10 : RB4/SCK/SCL
+  // Pin 11 : RB5/SS/TX/CK
+  // Pin 12 : RB6/AN5/PGC/T1OSO/T1CKI
+  // Pin 13 : RB7/AN6/PGD/T1OSI
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKO
+  // Pin 16 : RA7/OSC1/CLKI
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Code protection off
+  {$define _CP_ON          = $3FFE}  // 0000h to 0FFFh code-protected (all protected)
+
+  // CCPMX : CCP1 Pin Selection bit
+  {$define _CCPMX_RB0      = $3FFF}  // CCP1 function on RB0
+  {$define _CCPMX_RB3      = $3FFD}  // CCP1 function on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3FFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $3FFB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : Flash Program Memory Write Enable bits
+  {$define _WRT_OFF        = $3FFF}  // Write protection off
+  {$define _WRT_256        = $3FF7}  // 0000h to 00FFh write-protected, 0100h to 0FFFh may be modified by EECON control
+  {$define _WRT_2048       = $3FEF}  // 0000h to 07FFh write-protected, 0800h to 0FFFh may be modified by EECON control
+  {$define _WRT_ALL        = $3FE7}  // 0000h to 0FFFh write-protected
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $3FFF}  // Code protection off
+  {$define _CPD_ON         = $3FDF}  // Data EE memory code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $3FFF}  // RB3/PGM pin has PGM function, Low-Voltage Programming enabled
+  {$define _LVP_OFF        = $3FBF}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $3FFF}  // BOR enabled
+  {$define _BOREN_OFF      = $3F7F}  // BOR disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $3FFF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $3EFF}  // RA5/MCLR/VPP pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $9FFF}  // EXTRC oscillator; CLKO function on RA6/OSC2/CLKO
+  {$define _FOSC_EXTRCIO   = $97FF}  // EXTRC oscillator; port I/O function on RA6/OSC2/CLKO
+  {$define _FOSC_INTOSCCLK = $8FFF}  // INTRC oscillator; CLKO function on RA6/OSC2/CLKO pin and port I/O function on RA7/OSC1/CLKI pin
+  {$define _FOSC_INTOSCIO  = $87FF}  // INTRC oscillator; port I/O function on both RA6/OSC2/CLKO pin and RA7/OSC1/CLKI pin
+  {$define _FOSC_EC        = $1FFF}  // ECIO; port I/O function on RA6/OSC2/CLKO
+  {$define _FOSC_HS        = $17FF}  // HS oscillator
+  {$define _FOSC_XT        = $0FFF}  // XT oscillator
+  {$define _FOSC_LP        = $07FF}  // LP oscillator
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0003}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $0002}  // Internal External Switchover mode disabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $0003}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $0001}  // Fail-Safe Clock Monitor disabled
+
+implementation
+end.

--- a/PIC16F870.pas
+++ b/PIC16F870.pas
@@ -1,0 +1,334 @@
+unit PIC16F870;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F870'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-012:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08E:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1BF:GPR'} 
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:77'} // PIR1
+  {$SET_UNIMP_BITS '00D:10'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '08C:77'} // PIE1
+  {$SET_UNIMP_BITS '08D:10'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp/THV
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/AN4
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKI
+  // Pin 10 : OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3
+  // Pin 15 : RC4
+  // Pin 16 : RC5
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/PGM
+  // Pin 25 : RB4
+  // Pin 26 : RB5
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF  = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON   = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ALL    = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF    = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF    = $3BFF}  // Code Protection off
+  {$define _CPD_ON     = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON     = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF    = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON   = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF  = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF     = $607F}  // Code protection off
+  {$define _CP_ON      = $001F}  // All memory code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF  = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON   = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON    = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF   = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC = $63BFF}  // RC oscillator
+  {$define _FOSC_HS    = $43BFF}  // HS oscillator
+  {$define _FOSC_XT    = $23BFF}  // XT oscillator
+  {$define _FOSC_LP    = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F871.pas
+++ b/PIC16F871.pas
@@ -1,0 +1,380 @@
+unit PIC16F871;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F871'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_CCP1IF       : bit  absolute PIR1.3;
+  PIR1_TMR2IF       : bit  absolute PIR1.2;
+  PIR1_TMR1IF       : bit  absolute PIR1.1;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE2      : bit  absolute TRISE.3;
+  TRISE_TRISE1      : bit  absolute TRISE.2;
+  TRISE_TRISE0      : bit  absolute TRISE.1;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_CCP1IE       : bit  absolute PIE1.3;
+  PIE1_TMR2IE       : bit  absolute PIE1.2;
+  PIE1_TMR1IE       : bit  absolute PIE1.1;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  PR2               : byte absolute $0092;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-012:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON
+  {$SET_STATE_RAM '015-01A:SFR'}  // CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-08E:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '092-092:SFR'}  // PR2
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1BF:GPR'} 
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '009:07'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:F7'} // PIR1
+  {$SET_UNIMP_BITS '00D:10'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '089:F7'} // TRISE
+  {$SET_UNIMP_BITS '08C:F7'} // PIE1
+  {$SET_UNIMP_BITS '08D:10'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp/THV
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/AN4
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKI
+  // Pin 14 : OSC2/CLKO
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4
+  // Pin 24 : RC5
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT
+  // Pin 34 : RB1
+  // Pin 35 : RB2
+  // Pin 36 : RB3/PGM
+  // Pin 37 : RB4
+  // Pin 38 : RB5
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF  = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON   = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ALL    = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF    = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF    = $3BFF}  // Code Protection off
+  {$define _CPD_ON     = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON     = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF    = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON   = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF  = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF     = $607F}  // Code protection off
+  {$define _CP_ON      = $001F}  // All memory code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF  = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON   = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON    = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF   = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC = $63BFF}  // RC oscillator
+  {$define _FOSC_HS    = $43BFF}  // HS oscillator
+  {$define _FOSC_XT    = $23BFF}  // XT oscillator
+  {$define _FOSC_LP    = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F872.pas
+++ b/PIC16F872.pas
@@ -1,0 +1,338 @@
+unit PIC16F872;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F872'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_SSPIF        : bit  absolute PIR1.5;
+  PIR1_CCP1IF       : bit  absolute PIR1.4;
+  PIR1_TMR2IF       : bit  absolute PIR1.3;
+  PIR1_TMR1IF       : bit  absolute PIR1.2;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_SSPIE        : bit  absolute PIE1.5;
+  PIE1_CCP1IE       : bit  absolute PIE1.4;
+  PIE1_TMR2IE       : bit  absolute PIE1.3;
+  PIE1_TMR1IE       : bit  absolute PIE1.2;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-017:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08E:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '091-094:SFR'}  // SSPCON2, PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1BF:GPR'} 
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:59'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '08D:59'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKI
+  // Pin 10 : OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6
+  // Pin 18 : RC7
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/PGM
+  // Pin 25 : RB4
+  // Pin 26 : RB5
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF  = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON   = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ALL    = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF    = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF    = $3BFF}  // Code Protection off
+  {$define _CPD_ON     = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON     = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF    = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON   = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF  = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF     = $607F}  // Code protection off
+  {$define _CP_ON      = $001F}  // All memory code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF  = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON   = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON    = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF   = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC = $63BFF}  // RC oscillator
+  {$define _FOSC_HS    = $43BFF}  // HS oscillator
+  {$define _FOSC_XT    = $23BFF}  // XT oscillator
+  {$define _FOSC_LP    = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F873.pas
+++ b/PIC16F873.pas
@@ -1,0 +1,377 @@
+unit PIC16F873;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F873'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP2IF       : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP2IE       : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-01F:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08E:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '091-094:SFR'}  // SSPCON2, PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:59'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:59'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKIN
+  // Pin 10 : OSC2/CLKOUT
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/PGM
+  // Pin 25 : RB4
+  // Pin 26 : RB5
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF    = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON     = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ON       = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF      = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF      = $3BFF}  // Code Protection off
+  {$define _CPD_ON       = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON       = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF      = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON     = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF    = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF       = $607F}  // Code protection off
+  {$define _CP_UPPER_256 = $405F}  // 0F00h to 0FFFh code protected
+  {$define _CP_HALF      = $203F}  // 0800h to 0FFFh code protected
+  {$define _CP_ALL       = $001F}  // 0000h to 0FFFh code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF    = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON     = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON      = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF     = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC   = $63BFF}  // RC oscillator
+  {$define _FOSC_HS      = $43BFF}  // HS oscillator
+  {$define _FOSC_XT      = $23BFF}  // XT oscillator
+  {$define _FOSC_LP      = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F874.pas
+++ b/PIC16F874.pas
@@ -1,0 +1,421 @@
+unit PIC16F874;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F874'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP2IF       : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE2      : bit  absolute TRISE.3;
+  TRISE_TRISE1      : bit  absolute TRISE.2;
+  TRISE_TRISE0      : bit  absolute TRISE.1;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP2IE       : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-08E:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '091-094:SFR'}  // SSPCON2, PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '009:07'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:59'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '089:F7'} // TRISE
+  {$SET_UNIMP_BITS '08D:59'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKIN
+  // Pin 14 : OSC2/CLKOUT
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT
+  // Pin 34 : RB1
+  // Pin 35 : RB2
+  // Pin 36 : RB3/PGM
+  // Pin 37 : RB4
+  // Pin 38 : RB5
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF    = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON     = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ON       = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF      = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF      = $3BFF}  // Code Protection off
+  {$define _CPD_ON       = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON       = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF      = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON     = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF    = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF       = $607F}  // Code protection off
+  {$define _CP_UPPER_256 = $405F}  // 0F00h to 0FFFh code protected
+  {$define _CP_HALF      = $203F}  // 0800h to 0FFFh code protected
+  {$define _CP_ALL       = $001F}  // 0000h to 0FFFh code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF    = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON     = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON      = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF     = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC   = $63BFF}  // RC oscillator
+  {$define _FOSC_HS      = $43BFF}  // HS oscillator
+  {$define _FOSC_XT      = $23BFF}  // XT oscillator
+  {$define _FOSC_LP      = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F874A.pas
+++ b/PIC16F874A.pas
@@ -1,0 +1,441 @@
+unit PIC16F874A;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F874A'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP2IF       : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE2      : bit  absolute TRISE.3;
+  TRISE_TRISE1      : bit  absolute TRISE.2;
+  TRISE_TRISE0      : bit  absolute TRISE.1;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP2IE       : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-08E:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '091-094:SFR'}  // SSPCON2, PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09F:SFR'}  // CMCON, CVRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '009:07'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:59'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '089:F7'} // TRISE
+  {$SET_UNIMP_BITS '08D:59'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '09F:CF'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:0F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/VPP
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/VREF-/CVREF
+  // Pin  5 : RA3/AN3/VREF+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/SS/C2OUT
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : VDD
+  // Pin 12 : VSS
+  // Pin 13 : OSC1/CLKI
+  // Pin 14 : OSC2/CLKO
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : VSS
+  // Pin 32 : VDD
+  // Pin 33 : RB0/INT
+  // Pin 34 : RB1
+  // Pin 35 : RB2
+  // Pin 36 : RB3/PGM
+  // Pin 37 : RB4
+  // Pin 38 : RB5
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF      = $2FCF}  // Code protection off
+  {$define _CP_ON       = $2FCE}  // All program memory code-protected
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF   = $2FCF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON    = $2FCD}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : Flash Program Memory Write Enable bits
+  {$define _WRT_OFF     = $2FCF}  // Write protection off; all program memory may be written to by EECON control
+  {$define _WRT_256     = $2FCB}  // 0000h to 00FFh write-protected; 0100h to 0FFFh may be written to by EECON control
+  {$define _WRT_1FOURTH = $2FC7}  // 0000h to 03FFh write-protected; 0400h to 0FFFh may be written to by EECON control
+  {$define _WRT_HALF    = $2FC3}  // 0000h to 07FFh write-protected; 0800h to 0FFFh may be written to by EECON control
+
+  // CPD : Data EEPROM Memory Code Protection bit
+  {$define _CPD_OFF     = $2FDF}  // Data EEPROM code protection off
+  {$define _CPD_ON      = $2FCF}  // Data EEPROM code-protected
+
+  // LVP : Low-Voltage (Single-Supply) In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON      = $2FEF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF     = $2FCF}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON    = $2FCF}  // BOR enabled
+  {$define _BOREN_OFF   = $2F8F}  // BOR disabled
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF   = $2FCF}  // PWRT disabled
+  {$define _PWRTE_ON    = $2F4F}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON     = $2FCF}  // WDT enabled
+  {$define _WDTE_OFF    = $2ECF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC  = $2FCF}  // RC oscillator
+  {$define _FOSC_HS     = $2DCF}  // HS oscillator
+  {$define _FOSC_XT     = $2BCF}  // XT oscillator
+  {$define _FOSC_LP     = $29CF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F876.pas
+++ b/PIC16F876.pas
@@ -1,0 +1,377 @@
+unit PIC16F876;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F876'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP2IF       : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP2IE       : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '00A-01F:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '08A-08E:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '091-094:SFR'}  // SSPCON2, PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:59'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:59'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : Vss
+  // Pin  9 : OSC1/CLKIN
+  // Pin 10 : OSC2/CLKOUT
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/PGM
+  // Pin 25 : RB4
+  // Pin 26 : RB5
+  // Pin 27 : RB6/PGC
+  // Pin 28 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF    = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON     = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ON       = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF      = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF      = $3BFF}  // Code Protection off
+  {$define _CPD_ON       = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON       = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF      = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON     = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF    = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF       = $607F}  // Code protection off
+  {$define _CP_UPPER_256 = $405F}  // 1F00h to 1FFFh code protected
+  {$define _CP_HALF      = $203F}  // 1000h to 1FFFh code protected
+  {$define _CP_ALL       = $001F}  // 0000h to 1FFFh code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF    = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON     = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON      = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF     = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC   = $63BFF}  // RC oscillator
+  {$define _FOSC_HS      = $43BFF}  // HS oscillator
+  {$define _FOSC_XT      = $23BFF}  // XT oscillator
+  {$define _FOSC_LP      = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F877.pas
+++ b/PIC16F877.pas
@@ -1,0 +1,421 @@
+unit PIC16F877;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F877'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_PSPIF        : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_CCP2IF       : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1CKPS1     : bit  absolute T1CON.5;
+  T1CON_T1CKPS0     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_IBF         : bit  absolute TRISE.7;
+  TRISE_OBF         : bit  absolute TRISE.6;
+  TRISE_IBOV        : bit  absolute TRISE.5;
+  TRISE_PSPMODE     : bit  absolute TRISE.4;
+  TRISE_TRISE2      : bit  absolute TRISE.3;
+  TRISE_TRISE1      : bit  absolute TRISE.2;
+  TRISE_TRISE0      : bit  absolute TRISE.1;
+  PIE1              : byte absolute $008c;
+  PIE1_PSPIE        : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_CCP2IE       : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_PCFG3      : bit  absolute ADCON1.3;
+  ADCON1_PCFG2      : bit  absolute ADCON1.2;
+  ADCON1_PCFG1      : bit  absolute ADCON1.1;
+  ADCON1_PCFG0      : bit  absolute ADCON1.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-08E:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON
+  {$SET_STATE_RAM '091-094:SFR'}  // SSPCON2, PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09E-09F:SFR'}  // ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-104:SFR'}  // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_STATE_RAM '106-106:SFR'}  // PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:3F'} // PORTA
+  {$SET_UNIMP_BITS '009:07'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:59'} // PIR2
+  {$SET_UNIMP_BITS '010:3F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '085:3F'} // TRISA
+  {$SET_UNIMP_BITS '089:F7'} // TRISE
+  {$SET_UNIMP_BITS '08D:59'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09F:8F'} // ADCON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : MCLR/Vpp
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1
+  // Pin  4 : RA2/AN2/Vref-
+  // Pin  5 : RA3/AN3/Vref+
+  // Pin  6 : RA4/T0CKI
+  // Pin  7 : RA5/SS/AN4
+  // Pin  8 : RE0/RD/AN5
+  // Pin  9 : RE1/WR/AN6
+  // Pin 10 : RE2/CS/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : OSC1/CLKIN
+  // Pin 14 : OSC2/CLKOUT
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0/PSP0
+  // Pin 20 : RD1/PSP1
+  // Pin 21 : RD2/PSP2
+  // Pin 22 : RD3/PSP3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4/PSP4
+  // Pin 28 : RD5/PSP5
+  // Pin 29 : RD6/PSP6
+  // Pin 30 : RD7/PSP7
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT
+  // Pin 34 : RB1
+  // Pin 35 : RB2
+  // Pin 36 : RB3/PGM
+  // Pin 37 : RB4
+  // Pin 38 : RB5
+  // Pin 39 : RB6/PGC
+  // Pin 40 : RB7/PGD
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF    = $3BFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON     = $3BFE}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : FLASH Program Memory Write Enable
+  {$define _WRT_ON       = $3BFF}  // Unprotected program memory may be written to by EECON control
+  {$define _WRT_OFF      = $3BFD}  // Unprotected program memory may not be written to by EECON control
+
+  // CPD : Data EE Memory Code Protection
+  {$define _CPD_OFF      = $3BFF}  // Code Protection off
+  {$define _CPD_ON       = $3BFB}  // Data EEPROM memory code-protected
+
+  // LVP : Low Voltage In-Circuit Serial Programming Enable bit
+  {$define _LVP_ON       = $3BFF}  // RB3/PGM pin has PGM function; low-voltage programming enabled
+  {$define _LVP_OFF      = $3BF7}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON     = $3BFF}  // BOR enabled
+  {$define _BOREN_OFF    = $3BEF}  // BOR disabled
+
+  // CP : FLASH Program Memory Code Protection bits
+  {$define _CP_OFF       = $607F}  // Code protection off
+  {$define _CP_UPPER_256 = $405F}  // 1F00h to 1FFFh code protected
+  {$define _CP_HALF      = $203F}  // 1000h to 1FFFh code protected
+  {$define _CP_ALL       = $001F}  // 0000h to 1FFFh code protected
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF    = $BBFF}  // PWRT disabled
+  {$define _PWRTE_ON     = $3BFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON      = $13BFF}  // WDT enabled
+  {$define _WDTE_OFF     = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC   = $63BFF}  // RC oscillator
+  {$define _FOSC_HS      = $43BFF}  // HS oscillator
+  {$define _FOSC_XT      = $23BFF}  // XT oscillator
+  {$define _FOSC_LP      = $3BFF}  // LP oscillator
+
+implementation
+end.

--- a/PIC16F88.pas
+++ b/PIC16F88.pas
@@ -1,0 +1,400 @@
+unit PIC16F88;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F88'}
+{$SET PIC_MAXFREQ  = 10000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INT0IE     : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INT0IF     : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_CMIF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1RUN       : bit  absolute T1CON.6;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS2       : bit  absolute ADCON0.5;
+  ADCON0_CHS1       : bit  absolute ADCON0.4;
+  ADCON0_CHS0       : bit  absolute ADCON0.3;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.2;
+  ADCON0_ADON       : bit  absolute ADCON0.1;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_CMIE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PCON              : byte absolute $008e;
+  PCON_POR          : bit  absolute PCON.1;
+  PCON_BOR          : bit  absolute PCON.0;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_IOFS       : bit  absolute OSCCON.2;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN5      : bit  absolute OSCTUNE.5;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  ANSEL             : byte absolute $009b;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  CMCON             : byte absolute $009c;
+  CMCON_C2OUT       : bit  absolute CMCON.7;
+  CMCON_C1OUT       : bit  absolute CMCON.6;
+  CMCON_C2INV       : bit  absolute CMCON.5;
+  CMCON_C1INV       : bit  absolute CMCON.4;
+  CMCON_CIS         : bit  absolute CMCON.3;
+  CMCON_CM2         : bit  absolute CMCON.2;
+  CMCON_CM1         : bit  absolute CMCON.1;
+  CMCON_CM0         : bit  absolute CMCON.0;
+  CVRCON            : byte absolute $009d;
+  CVRCON_CVREN      : bit  absolute CVRCON.7;
+  CVRCON_CVROE      : bit  absolute CVRCON.6;
+  CVRCON_CVRR       : bit  absolute CVRCON.5;
+  CVRCON_CVR3       : bit  absolute CVRCON.3;
+  CVRCON_CVR2       : bit  absolute CVRCON.2;
+  CVRCON_CVR1       : bit  absolute CVRCON.1;
+  CVRCON_CVR0       : bit  absolute CVRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.7;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_FREE       : bit  absolute EECON1.6;
+  EECON1_WRERR      : bit  absolute EECON1.5;
+  EECON1_WREN       : bit  absolute EECON1.4;
+  EECON1_WR         : bit  absolute EECON1.3;
+  EECON1_RD         : bit  absolute EECON1.2;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '00A-01A:SFR'}  // PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-086:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB
+  {$SET_STATE_RAM '08A-090:SFR'}  // PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE
+  {$SET_STATE_RAM '092-094:SFR'}  // PR2, SSPADD, SSPSTAT
+  {$SET_STATE_RAM '098-099:SFR'}  // TXSTA, SPBRG
+  {$SET_STATE_RAM '09B-09F:SFR'}  // ANSEL, CMCON, CVRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-106:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB
+  {$SET_STATE_RAM '10A-10F:SFR'}  // PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:D0'} // PIR2
+  {$SET_UNIMP_BITS '010:7F'} // T1CON
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01F:FD'} // ADCON0
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:D0'} // PIE2
+  {$SET_UNIMP_BITS '08E:03'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:3F'} // OSCTUNE
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09B:7F'} // ANSEL
+  {$SET_UNIMP_BITS '09D:EF'} // CVRCON
+  {$SET_UNIMP_BITS '09F:F0'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:0F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:9F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2/AN2/CVref/Vref-
+  // Pin  2 : RA3/AN3/Vref+/C1OUT
+  // Pin  3 : RA4/AN4/T0CKI/C2OUT
+  // Pin  4 : RA5/MCLR/Vpp
+  // Pin  5 : Vss
+  // Pin  6 : RB0/INT/CCP1
+  // Pin  7 : RB1/SDI/SDA
+  // Pin  8 : RB2/SDO/RX/DT
+  // Pin  9 : RB3/PGM/CCP1
+  // Pin 10 : RB4/SCK/SCL
+  // Pin 11 : RB5/SS/TX/CK
+  // Pin 12 : RB6/AN5/PGC/T1OSO/T1CKI
+  // Pin 13 : RB7/AN6/PGD/T1OSI
+  // Pin 14 : Vdd
+  // Pin 15 : RA6/OSC2/CLKO
+  // Pin 16 : RA7/OSC1/CLKI
+  // Pin 17 : RA0/AN0
+  // Pin 18 : RA1/AN1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3,5-4,6-15,7-16'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // CP : Flash Program Memory Code Protection bit
+  {$define _CP_OFF         = $3FFF}  // Code protection off
+  {$define _CP_ON          = $3FFE}  // 0000h to 0FFFh code-protected (all protected)
+
+  // CCPMX : CCP1 Pin Selection bit
+  {$define _CCPMX_RB0      = $3FFF}  // CCP1 function on RB0
+  {$define _CCPMX_RB3      = $3FFD}  // CCP1 function on RB3
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $3FFF}  // In-Circuit Debugger disabled, RB6 and RB7 are general purpose I/O pins
+  {$define _DEBUG_ON       = $3FFB}  // In-Circuit Debugger enabled, RB6 and RB7 are dedicated to the debugger
+
+  // WRT : Flash Program Memory Write Enable bits
+  {$define _WRT_OFF        = $3FFF}  // Write protection off
+  {$define _WRT_256        = $3FF7}  // 0000h to 00FFh write-protected, 0100h to 0FFFh may be modified by EECON control
+  {$define _WRT_2048       = $3FEF}  // 0000h to 07FFh write-protected, 0800h to 0FFFh may be modified by EECON control
+  {$define _WRT_ALL        = $3FE7}  // 0000h to 0FFFh write-protected
+
+  // CPD : Data EE Memory Code Protection bit
+  {$define _CPD_OFF        = $3FFF}  // Code protection off
+  {$define _CPD_ON         = $3FDF}  // Data EE memory code-protected
+
+  // LVP : Low-Voltage Programming Enable bit
+  {$define _LVP_ON         = $3FFF}  // RB3/PGM pin has PGM function, Low-Voltage Programming enabled
+  {$define _LVP_OFF        = $3FBF}  // RB3 is digital I/O, HV on MCLR must be used for programming
+
+  // BOREN : Brown-out Reset Enable bit
+  {$define _BOREN_ON       = $3FFF}  // BOR enabled
+  {$define _BOREN_OFF      = $3F7F}  // BOR disabled
+
+  // MCLRE : RA5/MCLR/VPP Pin Function Select bit
+  {$define _MCLRE_ON       = $3FFF}  // RA5/MCLR/VPP pin function is MCLR
+  {$define _MCLRE_OFF      = $3EFF}  // RA5/MCLR/VPP pin function is digital I/O, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF      = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $3BFF}  // WDT disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $9FFF}  // EXTRC oscillator; CLKO function on RA6/OSC2/CLKO
+  {$define _FOSC_EXTRCIO   = $97FF}  // EXTRC oscillator; port I/O function on RA6/OSC2/CLKO
+  {$define _FOSC_INTOSCCLK = $8FFF}  // INTRC oscillator; CLKO function on RA6/OSC2/CLKO pin and port I/O function on RA7/OSC1/CLKI pin
+  {$define _FOSC_INTOSCIO  = $87FF}  // INTRC oscillator; port I/O function on both RA6/OSC2/CLKO pin and RA7/OSC1/CLKI pin
+  {$define _FOSC_EC        = $1FFF}  // ECIO; port I/O function on RA6/OSC2/CLKO
+  {$define _FOSC_HS        = $17FF}  // HS oscillator
+  {$define _FOSC_XT        = $0FFF}  // XT oscillator
+  {$define _FOSC_LP        = $07FF}  // LP oscillator
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $0003}  // Internal External Switchover mode enabled
+  {$define _IESO_OFF       = $0002}  // Internal External Switchover mode disabled
+
+  // FCMEN : Fail-Safe Clock Monitor Enable bit
+  {$define _FCMEN_ON       = $0003}  // Fail-Safe Clock Monitor enabled
+  {$define _FCMEN_OFF      = $0001}  // Fail-Safe Clock Monitor disabled
+
+implementation
+end.

--- a/PIC16F882.pas
+++ b/PIC16F882.pas
@@ -1,0 +1,571 @@
+unit PIC16F882;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F882'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_ULPWUIF      : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GIV       : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_DC2B1     : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_ULPWUIE      : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  IOCB_IOCB3        : bit  absolute IOCB.3;
+  IOCB_IOCB2        : bit  absolute IOCB.2;
+  IOCB_IOCB1        : bit  absolute IOCB.1;
+  IOCB_IOCB0        : bit  absolute IOCB.0;
+  VRCON             : byte absolute $0097;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VRSS        : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  PWM1CON           : byte absolute $009b;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $009c;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  PSTRCON           : byte absolute $009d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CM1CON0           : byte absolute $0107;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $0108;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $0109;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_C1RSEL    : bit  absolute CM2CON1.5;
+  CM2CON1_C2RSEL    : bit  absolute CM2CON1.4;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.3;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.2;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  SRCON             : byte absolute $0185;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+  SRCON_FVREN       : bit  absolute SRCON.1;
+  BAUDCTL           : byte absolute $0187;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ANSEL             : byte absolute $0188;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $0189;
+  ANSELH_ANS13      : bit  absolute ANSELH.5;
+  ANSELH_ANS12      : bit  absolute ANSELH.4;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-09F:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPMSK, SSPSTAT, WPUB, IOCB, VRCON, TXSTA, SPBRG, SPBRGH, PWM1CON, ECCPAS, PSTRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0BF:GPR'} 
+  {$SET_STATE_RAM '0F0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-10F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, CM1CON0, CM2CON0, CM2CON1, PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '170-17F:GPR'} 
+  {$SET_STATE_RAM '180-18D:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, SRCON, TRISB, BAUDCTL, ANSEL, ANSELH, PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:FD'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:08'} // TRISE
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:FD'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '09D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '09F:B0'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '107:FB'} // CM1CON0
+  {$SET_UNIMP_BITS '108:FB'} // CM2CON0
+  {$SET_UNIMP_BITS '109:F3'} // CM2CON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '185:FD'} // SRCON
+  {$SET_UNIMP_BITS '187:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '188:1F'} // ANSEL
+  {$SET_UNIMP_BITS '189:3F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/ULPWU/C12IN0-
+  // Pin  3 : RA1/AN1/C12IN1-
+  // Pin  4 : RA2/AN2/Vref-/CVref/C2IN+
+  // Pin  5 : RA3/AN3/Vref+/C1IN+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/SS/C2OUT
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKI
+  // Pin 10 : RA6/OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/P1A/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/INT
+  // Pin 22 : RB1/AN10/P1C/C12IN3-
+  // Pin 23 : RB2/AN8/P1B
+  // Pin 24 : RB3/AN9/PGM/C12IN2-
+  // Pin 25 : RB4/AN11/P1D
+  // Pin 26 : RB5/AN13/T1G
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF           = $3FFF}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON            = $3FFE}  // In_Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // LVP : Low Voltage Programming Enable bit
+  {$define _LVP_ON              = $3FFF}  // RB3/PGM pin has PGM function, low voltage programming enabled
+  {$define _LVP_OFF             = $3FFD}  // RB3 pin has digital I/O, HV on MCLR must be used for programming
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON            = $3FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF           = $3FFB}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON             = $3FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF            = $3FF7}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown Out Reset Selection bits
+  {$define _BOREN_ON            = $3FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP        = $3FEF}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN        = $3FDF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF           = $3FCF}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF             = $3FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON              = $3FBF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF              = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON               = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON            = $3FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF           = $3EFF}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF           = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON            = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON             = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF            = $3BFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC_CLKOUT   = $3FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRC_NOCLKOUT = $37FF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_CLKOUT   = $2FFF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_NOCLKOUT = $27FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC             = $1FFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS             = $17FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT             = $0FFF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP             = $07FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // WRT : Flash Program Memory Self Write Enable bits
+  {$define _WRT_HALF            = $0700}  // 0000h to 03FFh write protected, 0400h to 07FFh may be modified by EECON control
+  {$define _WRT_1FOURTH         = $0701}  // 0000h to 00FFh write protected, 0100h to 07FFh may be modified by EECON control
+  {$define _WRT_OFF             = $0703}  // Write protection off
+
+  // BOR4V : Brown-out Reset Selection bit
+  {$define _BOR4V_BOR21V        = $0700}  // Brown-out Reset set to 2.1V
+  {$define _BOR4V_BOR40V        = $0704}  // Brown-out Reset set to 4.0V
+
+implementation
+end.

--- a/PIC16F883.pas
+++ b/PIC16F883.pas
@@ -1,0 +1,571 @@
+unit PIC16F883;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F883'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_ULPWUIF      : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GIV       : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_DC2B1     : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_ULPWUIE      : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  IOCB_IOCB3        : bit  absolute IOCB.3;
+  IOCB_IOCB2        : bit  absolute IOCB.2;
+  IOCB_IOCB1        : bit  absolute IOCB.1;
+  IOCB_IOCB0        : bit  absolute IOCB.0;
+  VRCON             : byte absolute $0097;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VRSS        : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  PWM1CON           : byte absolute $009b;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $009c;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  PSTRCON           : byte absolute $009d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CM1CON0           : byte absolute $0107;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $0108;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $0109;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_C1RSEL    : bit  absolute CM2CON1.5;
+  CM2CON1_C2RSEL    : bit  absolute CM2CON1.4;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.3;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.2;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  SRCON             : byte absolute $0185;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+  SRCON_FVREN       : bit  absolute SRCON.1;
+  BAUDCTL           : byte absolute $0187;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ANSEL             : byte absolute $0188;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $0189;
+  ANSELH_ANS13      : bit  absolute ANSELH.5;
+  ANSELH_ANS12      : bit  absolute ANSELH.4;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-09F:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPMSK, SSPSTAT, WPUB, IOCB, VRCON, TXSTA, SPBRG, SPBRGH, PWM1CON, ECCPAS, PSTRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-10F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, CM1CON0, CM2CON0, CM2CON1, PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-18D:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, SRCON, TRISB, BAUDCTL, ANSEL, ANSELH, PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:FD'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:08'} // TRISE
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:FD'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '09D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '09F:B0'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '107:FB'} // CM1CON0
+  {$SET_UNIMP_BITS '108:FB'} // CM2CON0
+  {$SET_UNIMP_BITS '109:F3'} // CM2CON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '185:FD'} // SRCON
+  {$SET_UNIMP_BITS '187:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '188:1F'} // ANSEL
+  {$SET_UNIMP_BITS '189:3F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/ULPWU/C12IN0-
+  // Pin  3 : RA1/AN1/C12IN1-
+  // Pin  4 : RA2/AN2/Vref-/CVref/C2IN+
+  // Pin  5 : RA3/AN3/Vref+/C1IN+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/SS/C2OUT
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKI
+  // Pin 10 : RA6/OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/P1A/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/INT
+  // Pin 22 : RB1/AN10/P1C/C12IN3-
+  // Pin 23 : RB2/AN8/P1B
+  // Pin 24 : RB3/AN9/PGM/C12IN2-
+  // Pin 25 : RB4/AN11/P1D
+  // Pin 26 : RB5/AN13/T1G
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF           = $3FFF}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON            = $3FFE}  // In_Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // LVP : Low Voltage Programming Enable bit
+  {$define _LVP_ON              = $3FFF}  // RB3/PGM pin has PGM function, low voltage programming enabled
+  {$define _LVP_OFF             = $3FFD}  // RB3 pin has digital I/O, HV on MCLR must be used for programming
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON            = $3FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF           = $3FFB}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON             = $3FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF            = $3FF7}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown Out Reset Selection bits
+  {$define _BOREN_ON            = $3FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP        = $3FEF}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN        = $3FDF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF           = $3FCF}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF             = $3FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON              = $3FBF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF              = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON               = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON            = $3FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF           = $3EFF}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF           = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON            = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON             = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF            = $3BFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC_CLKOUT   = $3FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRC_NOCLKOUT = $37FF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_CLKOUT   = $2FFF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_NOCLKOUT = $27FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC             = $1FFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS             = $17FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT             = $0FFF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP             = $07FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // WRT : Flash Program Memory Self Write Enable bits
+  {$define _WRT_HALF            = $0700}  // 0000h to 07FFh write protected, 0800h to 0FFFh may be modified by EECON control
+  {$define _WRT_1FOURTH         = $0701}  // 0000h to 03FFh write protected, 0400h to 0FFFh may be modified by EECON control
+  {$define _WRT_256             = $0702}  // 0000h to 00FFh write protected, 0100h to 0FFFh may be modified by EECON control
+  {$define _WRT_OFF             = $0703}  // Write protection off
+
+  // BOR4V : Brown-out Reset Selection bit
+  {$define _BOR4V_BOR21V        = $0700}  // Brown-out Reset set to 2.1V
+  {$define _BOR4V_BOR40V        = $0704}  // Brown-out Reset set to 4.0V
+
+implementation
+end.

--- a/PIC16F884.pas
+++ b/PIC16F884.pas
@@ -1,0 +1,608 @@
+unit PIC16F884;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F884'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_ULPWUIF      : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GIV       : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_DC2B1     : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_ULPWUIE      : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  IOCB_IOCB3        : bit  absolute IOCB.3;
+  IOCB_IOCB2        : bit  absolute IOCB.2;
+  IOCB_IOCB1        : bit  absolute IOCB.1;
+  IOCB_IOCB0        : bit  absolute IOCB.0;
+  VRCON             : byte absolute $0097;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VRSS        : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  PWM1CON           : byte absolute $009b;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $009c;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  PSTRCON           : byte absolute $009d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CM1CON0           : byte absolute $0107;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $0108;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $0109;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_C1RSEL    : bit  absolute CM2CON1.5;
+  CM2CON1_C2RSEL    : bit  absolute CM2CON1.4;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.3;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.2;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  SRCON             : byte absolute $0185;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+  SRCON_FVREN       : bit  absolute SRCON.1;
+  BAUDCTL           : byte absolute $0187;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ANSEL             : byte absolute $0188;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $0189;
+  ANSELH_ANS13      : bit  absolute ANSELH.5;
+  ANSELH_ANS12      : bit  absolute ANSELH.4;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-09F:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPMSK, SSPSTAT, WPUB, IOCB, VRCON, TXSTA, SPBRG, SPBRGH, PWM1CON, ECCPAS, PSTRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-10F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, CM1CON0, CM2CON0, CM2CON1, PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-18D:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, SRCON, TRISB, BAUDCTL, ANSEL, ANSELH, PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:FD'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:FD'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '09D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '09F:B0'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '107:FB'} // CM1CON0
+  {$SET_UNIMP_BITS '108:FB'} // CM2CON0
+  {$SET_UNIMP_BITS '109:F3'} // CM2CON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '185:FD'} // SRCON
+  {$SET_UNIMP_BITS '187:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '189:3F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/ULPWU/C12IN0-
+  // Pin  3 : RA1/AN1/C12IN1-
+  // Pin  4 : RA2/AN2/Vref-/CVref/C2IN+
+  // Pin  5 : RA3/AN3/Vref+/C1IN+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/SS/C2OUT
+  // Pin  8 : RE0/AN5
+  // Pin  9 : RE1/AN6
+  // Pin 10 : RE2/AN7
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : RA7/OSC1/CLKIN
+  // Pin 14 : RA6/OSC2/CLKOUT
+  // Pin 15 : RC0/T1OSO/T1CKI
+  // Pin 16 : RC1/T1OSI/CCP2
+  // Pin 17 : RC2/P1A/CCP1
+  // Pin 18 : RC3/SCK/SCL
+  // Pin 19 : RD0
+  // Pin 20 : RD1
+  // Pin 21 : RD2
+  // Pin 22 : RD3
+  // Pin 23 : RC4/SDI/SDA
+  // Pin 24 : RC5/SDO
+  // Pin 25 : RC6/TX/CK
+  // Pin 26 : RC7/RX/DT
+  // Pin 27 : RD4
+  // Pin 28 : RD5/P1B
+  // Pin 29 : RD6/P1C
+  // Pin 30 : RD7/P1D
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/AN12/INT
+  // Pin 34 : RB1/AN10/C12IN3-
+  // Pin 35 : RB2/AN8
+  // Pin 36 : RB3/AN9/PGM/C12IN2-
+  // Pin 37 : RB4/AN11
+  // Pin 38 : RB5/AN13/T1G
+  // Pin 39 : RB6/ICSPCLK
+  // Pin 40 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF           = $3FFF}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON            = $3FFE}  // In_Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // LVP : Low Voltage Programming Enable bit
+  {$define _LVP_ON              = $3FFF}  // RB3/PGM pin has PGM function, low voltage programming enabled
+  {$define _LVP_OFF             = $3FFD}  // RB3 pin has digital I/O, HV on MCLR must be used for programming
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON            = $3FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF           = $3FFB}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON             = $3FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF            = $3FF7}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown Out Reset Selection bits
+  {$define _BOREN_ON            = $3FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP        = $3FEF}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN        = $3FDF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF           = $3FCF}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF             = $3FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON              = $3FBF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF              = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON               = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON            = $3FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF           = $3EFF}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF           = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON            = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON             = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF            = $3BFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC_CLKOUT   = $3FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRC_NOCLKOUT = $37FF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_CLKOUT   = $2FFF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_NOCLKOUT = $27FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC             = $1FFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS             = $17FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT             = $0FFF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP             = $07FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // WRT : Flash Program Memory Self Write Enable bits
+  {$define _WRT_HALF            = $0700}  // 0000h to 07FFh write protected, 0800h to 0FFFh may be modified by EECON control
+  {$define _WRT_1FOURTH         = $0701}  // 0000h to 03FFh write protected, 0400h to 0FFFh may be modified by EECON control
+  {$define _WRT_256             = $0702}  // 0000h to 00FFh write protected, 0100h to 0FFFh may be modified by EECON control
+  {$define _WRT_OFF             = $0703}  // Write protection off
+
+  // BOR4V : Brown-out Reset Selection bit
+  {$define _BOR4V_BOR21V        = $0700}  // Brown-out Reset set to 2.1V
+  {$define _BOR4V_BOR40V        = $0704}  // Brown-out Reset set to 4.0V
+
+implementation
+end.

--- a/PIC16F886.pas
+++ b/PIC16F886.pas
@@ -1,0 +1,571 @@
+unit PIC16F886;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F886'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_ULPWUIF      : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GIV       : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_DC2B1     : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_ULPWUIE      : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  IOCB_IOCB3        : bit  absolute IOCB.3;
+  IOCB_IOCB2        : bit  absolute IOCB.2;
+  IOCB_IOCB1        : bit  absolute IOCB.1;
+  IOCB_IOCB0        : bit  absolute IOCB.0;
+  VRCON             : byte absolute $0097;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VRSS        : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  PWM1CON           : byte absolute $009b;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $009c;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  PSTRCON           : byte absolute $009d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CM1CON0           : byte absolute $0107;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $0108;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $0109;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_C1RSEL    : bit  absolute CM2CON1.5;
+  CM2CON1_C2RSEL    : bit  absolute CM2CON1.4;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.3;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.2;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  SRCON             : byte absolute $0185;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+  SRCON_FVREN       : bit  absolute SRCON.1;
+  BAUDCTL           : byte absolute $0187;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ANSEL             : byte absolute $0188;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $0189;
+  ANSELH_ANS13      : bit  absolute ANSELH.5;
+  ANSELH_ANS12      : bit  absolute ANSELH.4;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01F:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-09F:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPMSK, SSPSTAT, WPUB, IOCB, VRCON, TXSTA, SPBRG, SPBRGH, PWM1CON, ECCPAS, PSTRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-10F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, CM1CON0, CM2CON0, CM2CON1, PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-18D:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, SRCON, TRISB, BAUDCTL, ANSEL, ANSELH, PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:FD'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:08'} // TRISE
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:FD'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '09D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '09F:B0'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '107:FB'} // CM1CON0
+  {$SET_UNIMP_BITS '108:FB'} // CM2CON0
+  {$SET_UNIMP_BITS '109:F3'} // CM2CON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '185:FD'} // SRCON
+  {$SET_UNIMP_BITS '187:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '188:1F'} // ANSEL
+  {$SET_UNIMP_BITS '189:3F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/ULPWU/C12IN0-
+  // Pin  3 : RA1/AN1/C12IN1-
+  // Pin  4 : RA2/AN2/Vref-/CVref/C2IN+
+  // Pin  5 : RA3/AN3/Vref+/C1IN+
+  // Pin  6 : RA4/T0CKI/C1OUT
+  // Pin  7 : RA5/AN4/SS/C2OUT
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKI
+  // Pin 10 : RA6/OSC2/CLKO
+  // Pin 11 : RC0/T1OSO/T1CKI
+  // Pin 12 : RC1/T1OSI/CCP2
+  // Pin 13 : RC2/P1A/CCP1
+  // Pin 14 : RC3/SCK/SCL
+  // Pin 15 : RC4/SDI/SDA
+  // Pin 16 : RC5/SDO
+  // Pin 17 : RC6/TX/CK
+  // Pin 18 : RC7/RX/DT
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/AN12/INT
+  // Pin 22 : RB1/AN10/P1C/C12IN3-
+  // Pin 23 : RB2/AN8/P1B
+  // Pin 24 : RB3/AN9/PGM/C12IN2-
+  // Pin 25 : RB4/AN11/P1D
+  // Pin 26 : RB5/AN13/T1G
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF           = $3FFF}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON            = $3FFE}  // In_Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // LVP : Low Voltage Programming Enable bit
+  {$define _LVP_ON              = $3FFF}  // RB3/PGM pin has PGM function, low voltage programming enabled
+  {$define _LVP_OFF             = $3FFD}  // RB3 pin has digital I/O, HV on MCLR must be used for programming
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON            = $3FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF           = $3FFB}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON             = $3FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF            = $3FF7}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown Out Reset Selection bits
+  {$define _BOREN_ON            = $3FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP        = $3FEF}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN        = $3FDF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF           = $3FCF}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF             = $3FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON              = $3FBF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF              = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON               = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON            = $3FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF           = $3EFF}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF           = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON            = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON             = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF            = $3BFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC_CLKOUT   = $3FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRC_NOCLKOUT = $37FF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_CLKOUT   = $2FFF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_NOCLKOUT = $27FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC             = $1FFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS             = $17FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT             = $0FFF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP             = $07FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // WRT : Flash Program Memory Self Write Enable bits
+  {$define _WRT_HALF            = $0700}  // 0000h to 0FFFh write protected, 1000h to 1FFFh may be modified by EECON control
+  {$define _WRT_1FOURTH         = $0701}  // 0000h to 07FFh write protected, 0800h to 1FFFh may be modified by EECON control
+  {$define _WRT_256             = $0702}  // 0000h to 00FFh write protected, 0100h to 1FFFh may be modified by EECON control
+  {$define _WRT_OFF             = $0703}  // Write protection off
+
+  // BOR4V : Brown-out Reset Selection bit
+  {$define _BOR4V_BOR21V        = $0700}  // Brown-out Reset set to 2.1V
+  {$define _BOR4V_BOR40V        = $0704}  // Brown-out Reset set to 4.0V
+
+implementation
+end.

--- a/PIC16F887.pas
+++ b/PIC16F887.pas
@@ -1,0 +1,608 @@
+unit PIC16F887;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F887'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_T0IE       : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_T0IF       : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.7;
+  PIR2_C2IF         : bit  absolute PIR2.6;
+  PIR2_C1IF         : bit  absolute PIR2.5;
+  PIR2_EEIF         : bit  absolute PIR2.4;
+  PIR2_BCLIF        : bit  absolute PIR2.3;
+  PIR2_ULPWUIF      : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GIV       : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_P1M1      : bit  absolute CCP1CON.7;
+  CCP1CON_P1M0      : bit  absolute CCP1CON.6;
+  CCP1CON_DC1B1     : bit  absolute CCP1CON.5;
+  CCP1CON_DC1B0     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_DC2B1     : bit  absolute CCP2CON.5;
+  CCP2CON_DC2B0     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADCS1      : bit  absolute ADCON0.7;
+  ADCON0_ADCS0      : bit  absolute ADCON0.6;
+  ADCON0_CHS3       : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.7;
+  PIE2_C2IE         : bit  absolute PIE2.6;
+  PIE2_C1IE         : bit  absolute PIE2.5;
+  PIE2_EEIE         : bit  absolute PIE2.4;
+  PIE2_BCLIE        : bit  absolute PIE2.3;
+  PIE2_ULPWUIE      : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_ULPWUE       : bit  absolute PCON.5;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  SSPCON2           : byte absolute $0091;
+  SSPCON2_GCEN      : bit  absolute SSPCON2.7;
+  SSPCON2_ACKSTAT   : bit  absolute SSPCON2.6;
+  SSPCON2_ACKDT     : bit  absolute SSPCON2.5;
+  SSPCON2_ACKEN     : bit  absolute SSPCON2.4;
+  SSPCON2_RCEN      : bit  absolute SSPCON2.3;
+  SSPCON2_PEN       : bit  absolute SSPCON2.2;
+  SSPCON2_RSEN      : bit  absolute SSPCON2.1;
+  SSPCON2_SEN       : bit  absolute SSPCON2.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPMSK            : byte absolute $0093;
+  SSPMSK_MSK7       : bit  absolute SSPMSK.7;
+  SSPMSK_MSK6       : bit  absolute SSPMSK.6;
+  SSPMSK_MSK5       : bit  absolute SSPMSK.5;
+  SSPMSK_MSK4       : bit  absolute SSPMSK.4;
+  SSPMSK_MSK3       : bit  absolute SSPMSK.3;
+  SSPMSK_MSK2       : bit  absolute SSPMSK.2;
+  SSPMSK_MSK1       : bit  absolute SSPMSK.1;
+  SSPMSK_MSK0       : bit  absolute SSPMSK.0;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  IOCB_IOCB3        : bit  absolute IOCB.3;
+  IOCB_IOCB2        : bit  absolute IOCB.2;
+  IOCB_IOCB1        : bit  absolute IOCB.1;
+  IOCB_IOCB0        : bit  absolute IOCB.0;
+  VRCON             : byte absolute $0097;
+  VRCON_VREN        : bit  absolute VRCON.7;
+  VRCON_VROE        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VRSS        : bit  absolute VRCON.4;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_SENDB       : bit  absolute TXSTA.3;
+  TXSTA_BRGH        : bit  absolute TXSTA.2;
+  TXSTA_TRMT        : bit  absolute TXSTA.1;
+  TXSTA_TX9D        : bit  absolute TXSTA.0;
+  SPBRG             : byte absolute $0099;
+  SPBRG_BRG7        : bit  absolute SPBRG.7;
+  SPBRG_BRG6        : bit  absolute SPBRG.6;
+  SPBRG_BRG5        : bit  absolute SPBRG.5;
+  SPBRG_BRG4        : bit  absolute SPBRG.4;
+  SPBRG_BRG3        : bit  absolute SPBRG.3;
+  SPBRG_BRG2        : bit  absolute SPBRG.2;
+  SPBRG_BRG1        : bit  absolute SPBRG.1;
+  SPBRG_BRG0        : bit  absolute SPBRG.0;
+  SPBRGH            : byte absolute $009a;
+  SPBRGH_BRG15      : bit  absolute SPBRGH.7;
+  SPBRGH_BRG14      : bit  absolute SPBRGH.6;
+  SPBRGH_BRG13      : bit  absolute SPBRGH.5;
+  SPBRGH_BRG12      : bit  absolute SPBRGH.4;
+  SPBRGH_BRG11      : bit  absolute SPBRGH.3;
+  SPBRGH_BRG10      : bit  absolute SPBRGH.2;
+  SPBRGH_BRG9       : bit  absolute SPBRGH.1;
+  SPBRGH_BRG8       : bit  absolute SPBRGH.0;
+  PWM1CON           : byte absolute $009b;
+  PWM1CON_PRSEN     : bit  absolute PWM1CON.7;
+  PWM1CON_PDC6      : bit  absolute PWM1CON.6;
+  PWM1CON_PDC5      : bit  absolute PWM1CON.5;
+  PWM1CON_PDC4      : bit  absolute PWM1CON.4;
+  PWM1CON_PDC3      : bit  absolute PWM1CON.3;
+  PWM1CON_PDC2      : bit  absolute PWM1CON.2;
+  PWM1CON_PDC1      : bit  absolute PWM1CON.1;
+  PWM1CON_PDC0      : bit  absolute PWM1CON.0;
+  ECCPAS            : byte absolute $009c;
+  ECCPAS_ECCPASE    : bit  absolute ECCPAS.7;
+  ECCPAS_ECCPAS2    : bit  absolute ECCPAS.6;
+  ECCPAS_ECCPAS1    : bit  absolute ECCPAS.5;
+  ECCPAS_ECCPAS0    : bit  absolute ECCPAS.4;
+  ECCPAS_PSSAC1     : bit  absolute ECCPAS.3;
+  ECCPAS_PSSAC0     : bit  absolute ECCPAS.2;
+  ECCPAS_PSSBD1     : bit  absolute ECCPAS.1;
+  ECCPAS_PSSBD0     : bit  absolute ECCPAS.0;
+  PSTRCON           : byte absolute $009d;
+  PSTRCON_STRSYNC   : bit  absolute PSTRCON.4;
+  PSTRCON_STRD      : bit  absolute PSTRCON.3;
+  PSTRCON_STRC      : bit  absolute PSTRCON.2;
+  PSTRCON_STRB      : bit  absolute PSTRCON.1;
+  PSTRCON_STRA      : bit  absolute PSTRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADFM       : bit  absolute ADCON1.6;
+  ADCON1_VCFG1      : bit  absolute ADCON1.5;
+  ADCON1_VCFG0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  CM1CON0           : byte absolute $0107;
+  CM1CON0_C1ON      : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUT     : bit  absolute CM1CON0.6;
+  CM1CON0_C1OE      : bit  absolute CM1CON0.5;
+  CM1CON0_C1POL     : bit  absolute CM1CON0.4;
+  CM1CON0_C1R       : bit  absolute CM1CON0.3;
+  CM1CON0_C1CH1     : bit  absolute CM1CON0.1;
+  CM1CON0_C1CH0     : bit  absolute CM1CON0.0;
+  CM2CON0           : byte absolute $0108;
+  CM2CON0_C2ON      : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUT     : bit  absolute CM2CON0.6;
+  CM2CON0_C2OE      : bit  absolute CM2CON0.5;
+  CM2CON0_C2POL     : bit  absolute CM2CON0.4;
+  CM2CON0_C2R       : bit  absolute CM2CON0.3;
+  CM2CON0_C2CH1     : bit  absolute CM2CON0.1;
+  CM2CON0_C2CH0     : bit  absolute CM2CON0.0;
+  CM2CON1           : byte absolute $0109;
+  CM2CON1_MC1OUT    : bit  absolute CM2CON1.7;
+  CM2CON1_MC2OUT    : bit  absolute CM2CON1.6;
+  CM2CON1_C1RSEL    : bit  absolute CM2CON1.5;
+  CM2CON1_C2RSEL    : bit  absolute CM2CON1.4;
+  CM2CON1_T1GSS     : bit  absolute CM2CON1.3;
+  CM2CON1_C2SYNC    : bit  absolute CM2CON1.2;
+  EEDATA            : byte absolute $010c;
+  EEADR             : byte absolute $010d;
+  EEDATH            : byte absolute $010e;
+  EEADRH            : byte absolute $010f;
+  SRCON             : byte absolute $0185;
+  SRCON_SR1         : bit  absolute SRCON.7;
+  SRCON_SR0         : bit  absolute SRCON.6;
+  SRCON_C1SEN       : bit  absolute SRCON.5;
+  SRCON_C2REN       : bit  absolute SRCON.4;
+  SRCON_PULSS       : bit  absolute SRCON.3;
+  SRCON_PULSR       : bit  absolute SRCON.2;
+  SRCON_FVREN       : bit  absolute SRCON.1;
+  BAUDCTL           : byte absolute $0187;
+  BAUDCTL_ABDOVF    : bit  absolute BAUDCTL.6;
+  BAUDCTL_RCIDL     : bit  absolute BAUDCTL.5;
+  BAUDCTL_SCKP      : bit  absolute BAUDCTL.4;
+  BAUDCTL_BRG16     : bit  absolute BAUDCTL.3;
+  BAUDCTL_WUE       : bit  absolute BAUDCTL.2;
+  BAUDCTL_ABDEN     : bit  absolute BAUDCTL.1;
+  ANSEL             : byte absolute $0188;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  ANSELH            : byte absolute $0189;
+  ANSELH_ANS13      : bit  absolute ANSELH.5;
+  ANSELH_ANS12      : bit  absolute ANSELH.4;
+  ANSELH_ANS11      : bit  absolute ANSELH.3;
+  ANSELH_ANS10      : bit  absolute ANSELH.2;
+  ANSELH_ANS9       : bit  absolute ANSELH.1;
+  ANSELH_ANS8       : bit  absolute ANSELH.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-09F:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, SSPCON2, PR2, SSPMSK, SSPSTAT, WPUB, IOCB, VRCON, TXSTA, SPBRG, SPBRGH, PWM1CON, ECCPAS, PSTRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-10F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, CM1CON0, CM2CON0, CM2CON1, PCLATH, INTCON, EEDATA, EEADR, EEDATH, EEADRH
+  {$SET_STATE_RAM '110-17F:GPR'} 
+  {$SET_STATE_RAM '180-18D:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, SRCON, TRISB, BAUDCTL, ANSEL, ANSELH, PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00C:7F'} // PIR1
+  {$SET_UNIMP_BITS '00D:FD'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08C:7F'} // PIE1
+  {$SET_UNIMP_BITS '08D:FD'} // PIE2
+  {$SET_UNIMP_BITS '08E:33'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '093:00'} // SSPMSK
+  {$SET_UNIMP_BITS '09D:1F'} // PSTRCON
+  {$SET_UNIMP_BITS '09F:B0'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '107:FB'} // CM1CON0
+  {$SET_UNIMP_BITS '108:FB'} // CM2CON0
+  {$SET_UNIMP_BITS '109:F3'} // CM2CON1
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '185:FD'} // SRCON
+  {$SET_UNIMP_BITS '187:DB'} // BAUDCTL
+  {$SET_UNIMP_BITS '189:3F'} // ANSELH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RC7/RX/DT
+  // Pin  2 : RD4
+  // Pin  3 : RD5/P1B
+  // Pin  4 : RD6/P1C
+  // Pin  5 : RD7/P1D
+  // Pin  6 : VSS
+  // Pin  7 : VDD
+  // Pin  8 : RB0/AN12/INT
+  // Pin  9 : RB1/AN10/C12IN3-
+  // Pin 10 : RB2/AN8
+  // Pin 11 : RB3/AN9/PGM/C12IN2-
+  // Pin 12 : RB4/AN11
+  // Pin 13 : RB5/AN13/T1G
+  // Pin 14 : RB6/ICSPCLK
+  // Pin 15 : RB7/ICSPDAT
+  // Pin 16 : RE3/nMCLR/VPP
+  // Pin 17 : RA0/AN0/ULPWU/C12IN0-
+  // Pin 18 : RA1/AN1/C12IN1-
+  // Pin 19 : RA2/AN2/VREF-/CVREF/C2IN+
+  // Pin 20 : RA3/AN3/VREF+/C1IN+
+  // Pin 21 : RA4/T0CKI/C1OUT
+  // Pin 22 : RA5/AN4/nSS/C2OUT
+  // Pin 23 : RE0/AN5
+  // Pin 24 : RE1/AN6
+  // Pin 25 : RE2/AN7
+  // Pin 26 : VDD
+  // Pin 27 : VSS
+  // Pin 28 : RA7/OSC1/CLKIN
+  // Pin 29 : RA6/OSC2/CLKOUT
+  // Pin 30 : RC0/T1OSO/T1CKI
+  // Pin 31 : RC1/T1OSCI/CCP2
+  // Pin 32 : RC2/P1A/CCP1
+  // Pin 33 : RC3/SCK/SCL
+  // Pin 34 : RD0
+  // Pin 35 : RD1
+  // Pin 36 : RD2
+  // Pin 37 : RD3
+  // Pin 38 : RC4/SDI/SDA
+  // Pin 39 : RC5/SDO
+  // Pin 40 : RC6/TX/CK
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-19,3-20,4-21,5-22,6-29,7-28'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-8,1-9,2-10,3-11,4-12,5-13,6-14,7-15'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-30,1-31,2-32,3-33,4-38,5-39,6-40,7-1'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-34,1-35,2-36,3-37,4-2,5-3,6-4,7-5'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-23,1-24,2-25,3-16'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF           = $3FFF}  // In-Circuit Debugger disabled, RB6/ICSPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON            = $3FFE}  // In_Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // LVP : Low Voltage Programming Enable bit
+  {$define _LVP_ON              = $3FFF}  // RB3/PGM pin has PGM function, low voltage programming enabled
+  {$define _LVP_OFF             = $3FFD}  // RB3 pin has digital I/O, HV on MCLR must be used for programming
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON            = $3FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF           = $3FFB}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON             = $3FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF            = $3FF7}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown Out Reset Selection bits
+  {$define _BOREN_ON            = $3FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP        = $3FEF}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN        = $3FDF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF           = $3FCF}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF             = $3FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON              = $3FBF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF              = $3FFF}  // Program memory code protection is disabled
+  {$define _CP_ON               = $3F7F}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON            = $3FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF           = $3EFF}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power-up Timer Enable bit
+  {$define _PWRTE_OFF           = $3FFF}  // PWRT disabled
+  {$define _PWRTE_ON            = $3DFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON             = $3FFF}  // WDT enabled
+  {$define _WDTE_OFF            = $3BFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRC_CLKOUT   = $3FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_EXTRC_NOCLKOUT = $37FF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, RC on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_CLKOUT   = $2FFF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_INTRC_NOCLKOUT = $27FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT pin, I/O function on RA7/OSC1/CLKIN
+  {$define _FOSC_EC             = $1FFF}  // EC: I/O function on RA6/OSC2/CLKOUT pin, CLKIN on RA7/OSC1/CLKIN
+  {$define _FOSC_HS             = $17FF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_XT             = $0FFF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+  {$define _FOSC_LP             = $07FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT and RA7/OSC1/CLKIN
+
+  // WRT : Flash Program Memory Self Write Enable bits
+  {$define _WRT_HALF            = $0700}  // 0000h to 0FFFh write protected, 1000h to 1FFFh may be modified by EECON control
+  {$define _WRT_1FOURTH         = $0701}  // 0000h to 07FFh write protected, 0800h to 1FFFh may be modified by EECON control
+  {$define _WRT_256             = $0702}  // 0000h to 00FFh write protected, 0100h to 1FFFh may be modified by EECON control
+  {$define _WRT_OFF             = $0703}  // Write protection off
+
+  // BOR4V : Brown-out Reset Selection bit
+  {$define _BOR4V_BOR21V        = $0700}  // Brown-out Reset set to 2.1V
+  {$define _BOR4V_BOR40V        = $0704}  // Brown-out Reset set to 4.0V
+
+implementation
+end.

--- a/PIC16F913.pas
+++ b/PIC16F913.pas
@@ -1,0 +1,524 @@
+unit PIC16F913;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F913'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_C2IF         : bit  absolute PIR2.5;
+  PIR2_C1IF         : bit  absolute PIR2.4;
+  PIR2_LCDIF        : bit  absolute PIR2.3;
+  PIR2_LVDIF        : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GE        : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG1      : bit  absolute ADCON0.6;
+  ADCON0_VCFG0      : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_C2IE         : bit  absolute PIE2.5;
+  PIE2_C1IE         : bit  absolute PIE2.4;
+  PIE2_LCDIE        : bit  absolute PIE2.3;
+  PIE2_LVDIE        : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  CMCON1            : byte absolute $0097;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON0            : byte absolute $009c;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  VRCON             : byte absolute $009d;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LCDCON            : byte absolute $0107;
+  LCDCON_LCDEN      : bit  absolute LCDCON.7;
+  LCDCON_SLPEN      : bit  absolute LCDCON.6;
+  LCDCON_WERR       : bit  absolute LCDCON.5;
+  LCDCON_VLCDEN     : bit  absolute LCDCON.4;
+  LCDCON_CS1        : bit  absolute LCDCON.3;
+  LCDCON_CS0        : bit  absolute LCDCON.2;
+  LCDCON_LMUX1      : bit  absolute LCDCON.1;
+  LCDCON_LMUX0      : bit  absolute LCDCON.0;
+  LCDPS             : byte absolute $0108;
+  LCDPS_WFT         : bit  absolute LCDPS.7;
+  LCDPS_BIASMD      : bit  absolute LCDPS.6;
+  LCDPS_LCDA        : bit  absolute LCDPS.5;
+  LCDPS_WA          : bit  absolute LCDPS.4;
+  LCDPS_LP3         : bit  absolute LCDPS.3;
+  LCDPS_LP2         : bit  absolute LCDPS.2;
+  LCDPS_LP1         : bit  absolute LCDPS.1;
+  LCDPS_LP0         : bit  absolute LCDPS.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  EEDATL            : byte absolute $010c;
+  EEDATL_EEDATL7    : bit  absolute EEDATL.7;
+  EEDATL_EEDATL6    : bit  absolute EEDATL.6;
+  EEDATL_EEDATL5    : bit  absolute EEDATL.5;
+  EEDATL_EEDATL4    : bit  absolute EEDATL.4;
+  EEDATL_EEDATL3    : bit  absolute EEDATL.3;
+  EEDATL_EEDATL2    : bit  absolute EEDATL.2;
+  EEDATL_EEDATL1    : bit  absolute EEDATL.1;
+  EEDATL_EEDATL0    : bit  absolute EEDATL.0;
+  EEADRL            : byte absolute $010d;
+  EEADRL_EEADRL7    : bit  absolute EEADRL.7;
+  EEADRL_EEADRL6    : bit  absolute EEADRL.6;
+  EEADRL_EEADRL5    : bit  absolute EEADRL.5;
+  EEADRL_EEADRL4    : bit  absolute EEADRL.4;
+  EEADRL_EEADRL3    : bit  absolute EEADRL.3;
+  EEADRL_EEADRL2    : bit  absolute EEADRL.2;
+  EEADRL_EEADRL1    : bit  absolute EEADRL.1;
+  EEADRL_EEADRL0    : bit  absolute EEADRL.0;
+  EEDATH            : byte absolute $010e;
+  EEDATH_EEDATH5    : bit  absolute EEDATH.5;
+  EEDATH_EEDATH4    : bit  absolute EEDATH.4;
+  EEDATH_EEDATH3    : bit  absolute EEDATH.3;
+  EEDATH_EEDATH2    : bit  absolute EEDATH.2;
+  EEDATH_EEDATH1    : bit  absolute EEDATH.1;
+  EEDATH_EEDATH0    : bit  absolute EEDATH.0;
+  EEADRH            : byte absolute $010f;
+  EEADRH_EEADRH4    : bit  absolute EEADRH.4;
+  EEADRH_EEADRH3    : bit  absolute EEADRH.3;
+  EEADRH_EEADRH2    : bit  absolute EEADRH.2;
+  EEADRH_EEADRH1    : bit  absolute EEADRH.1;
+  EEADRH_EEADRH0    : bit  absolute EEADRH.0;
+  LCDDATA0          : byte absolute $0110;
+  LCDDATA0_SEG7     : bit  absolute LCDDATA0.7;
+  LCDDATA0_SEG6     : bit  absolute LCDDATA0.6;
+  LCDDATA0_SEG5     : bit  absolute LCDDATA0.5;
+  LCDDATA0_SEG4     : bit  absolute LCDDATA0.4;
+  LCDDATA0_SEG3     : bit  absolute LCDDATA0.3;
+  LCDDATA0_SEG2     : bit  absolute LCDDATA0.2;
+  LCDDATA0_SEG1     : bit  absolute LCDDATA0.1;
+  LCDDATA0_SEG0     : bit  absolute LCDDATA0.0;
+  LCDDATA1          : byte absolute $0111;
+  LCDDATA1_SEG15    : bit  absolute LCDDATA1.7;
+  LCDDATA1_SEG14    : bit  absolute LCDDATA1.6;
+  LCDDATA1_SEG13    : bit  absolute LCDDATA1.5;
+  LCDDATA1_SEG12    : bit  absolute LCDDATA1.4;
+  LCDDATA1_SEG11    : bit  absolute LCDDATA1.3;
+  LCDDATA1_SEG10    : bit  absolute LCDDATA1.2;
+  LCDDATA1_SEG9     : bit  absolute LCDDATA1.1;
+  LCDDATA1_SEG8     : bit  absolute LCDDATA1.0;
+  LCDDATA3          : byte absolute $0113;
+  LCDDATA4          : byte absolute $0114;
+  LCDDATA6          : byte absolute $0116;
+  LCDDATA7          : byte absolute $0117;
+  LCDDATA9          : byte absolute $0119;
+  LCDDATA10         : byte absolute $011a;
+  LCDSE0            : byte absolute $011c;
+  LCDSE1            : byte absolute $011d;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01A:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-099:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, ANSEL, PR2, SSPADD, SSPSTAT, WPUB, IOCB, CMCON1, TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09F:SFR'}  // CMCON0, VRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-111:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, LCDCON, LCDPS, LVDCON, PCLATH, INTCON, EEDATL, EEADRL, EEDATH, EEADRH, LCDDATA0, LCDDATA1
+  {$SET_STATE_RAM '113-114:SFR'}  // LCDDATA3, LCDDATA4
+  {$SET_STATE_RAM '116-117:SFR'}  // LCDDATA6, LCDDATA7
+  {$SET_STATE_RAM '119-11A:SFR'}  // LCDDATA9, LCDDATA10
+  {$SET_STATE_RAM '11C-11D:SFR'}  // LCDSE0, LCDSE1
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:F4'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '089:08'} // TRISE
+  {$SET_UNIMP_BITS '08D:F4'} // PIE2
+  {$SET_UNIMP_BITS '08E:13'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '091:1F'} // ANSEL
+  {$SET_UNIMP_BITS '096:F0'} // IOCB
+  {$SET_UNIMP_BITS '097:03'} // CMCON1
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:AF'} // VRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:37'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/C1-/SEG12
+  // Pin  3 : RA1/AN1/C2-/SEG7
+  // Pin  4 : RA2/AN2/C2+/VREF-/COM2
+  // Pin  5 : RA3/AN3/C1+/VREF+/COM3/SEG15
+  // Pin  6 : RA4/C1OUT/T0CKI/SEG4
+  // Pin  7 : RA5/AN4/C2OUT/SS/SEG5
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKIN/T1OSI
+  // Pin 10 : RA6/OSC2/CLKOUT/T1OSO
+  // Pin 11 : RC0/VLCD1
+  // Pin 12 : RC1/VLCD2
+  // Pin 13 : RC2/VLCD3
+  // Pin 14 : RC3/SEG6
+  // Pin 15 : RC4/T1G/SDO/SEG11
+  // Pin 16 : RC5/T1CKI/CCP1/SEG10
+  // Pin 17 : RC6/TX/CK/SCK/SCL/SEG9
+  // Pin 18 : RC7/RX/DT/SDI/SDA/SEG8
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT/SEG0
+  // Pin 22 : RB1/SEG1
+  // Pin 23 : RB2/SEG2
+  // Pin 24 : RB3/SEG3
+  // Pin 25 : RB4/COM0
+  // Pin 26 : RB5/COM1
+  // Pin 27 : RB6/ICSPCK/ICDCK/SEG14
+  // Pin 28 : RB7/ICSPDAT/ICDDAT/SEG13
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $1FFF}  // In-Circuit Debugger disabled, RB6/ISCPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $1FFE}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $1FEF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $1FE7}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $1FDF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $1F7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power Up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, CLKIN on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+
+implementation
+end.

--- a/PIC16F914.pas
+++ b/PIC16F914.pas
@@ -1,0 +1,581 @@
+unit PIC16F914;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F914'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 4096}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_C2IF         : bit  absolute PIR2.5;
+  PIR2_C1IF         : bit  absolute PIR2.4;
+  PIR2_LCDIF        : bit  absolute PIR2.3;
+  PIR2_LVDIF        : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GE        : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG1      : bit  absolute ADCON0.6;
+  ADCON0_VCFG0      : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_C2IE         : bit  absolute PIE2.5;
+  PIE2_C1IE         : bit  absolute PIE2.4;
+  PIE2_LCDIE        : bit  absolute PIE2.3;
+  PIE2_LVDIE        : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  CMCON1            : byte absolute $0097;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON0            : byte absolute $009c;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  VRCON             : byte absolute $009d;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LCDCON            : byte absolute $0107;
+  LCDCON_LCDEN      : bit  absolute LCDCON.7;
+  LCDCON_SLPEN      : bit  absolute LCDCON.6;
+  LCDCON_WERR       : bit  absolute LCDCON.5;
+  LCDCON_VLCDEN     : bit  absolute LCDCON.4;
+  LCDCON_CS1        : bit  absolute LCDCON.3;
+  LCDCON_CS0        : bit  absolute LCDCON.2;
+  LCDCON_LMUX1      : bit  absolute LCDCON.1;
+  LCDCON_LMUX0      : bit  absolute LCDCON.0;
+  LCDPS             : byte absolute $0108;
+  LCDPS_WFT         : bit  absolute LCDPS.7;
+  LCDPS_BIASMD      : bit  absolute LCDPS.6;
+  LCDPS_LCDA        : bit  absolute LCDPS.5;
+  LCDPS_WA          : bit  absolute LCDPS.4;
+  LCDPS_LP3         : bit  absolute LCDPS.3;
+  LCDPS_LP2         : bit  absolute LCDPS.2;
+  LCDPS_LP1         : bit  absolute LCDPS.1;
+  LCDPS_LP0         : bit  absolute LCDPS.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  EEDATL            : byte absolute $010c;
+  EEDATL_EEDATL7    : bit  absolute EEDATL.7;
+  EEDATL_EEDATL6    : bit  absolute EEDATL.6;
+  EEDATL_EEDATL5    : bit  absolute EEDATL.5;
+  EEDATL_EEDATL4    : bit  absolute EEDATL.4;
+  EEDATL_EEDATL3    : bit  absolute EEDATL.3;
+  EEDATL_EEDATL2    : bit  absolute EEDATL.2;
+  EEDATL_EEDATL1    : bit  absolute EEDATL.1;
+  EEDATL_EEDATL0    : bit  absolute EEDATL.0;
+  EEADRL            : byte absolute $010d;
+  EEADRL_EEADRL7    : bit  absolute EEADRL.7;
+  EEADRL_EEADRL6    : bit  absolute EEADRL.6;
+  EEADRL_EEADRL5    : bit  absolute EEADRL.5;
+  EEADRL_EEADRL4    : bit  absolute EEADRL.4;
+  EEADRL_EEADRL3    : bit  absolute EEADRL.3;
+  EEADRL_EEADRL2    : bit  absolute EEADRL.2;
+  EEADRL_EEADRL1    : bit  absolute EEADRL.1;
+  EEADRL_EEADRL0    : bit  absolute EEADRL.0;
+  EEDATH            : byte absolute $010e;
+  EEDATH_EEDATH5    : bit  absolute EEDATH.5;
+  EEDATH_EEDATH4    : bit  absolute EEDATH.4;
+  EEDATH_EEDATH3    : bit  absolute EEDATH.3;
+  EEDATH_EEDATH2    : bit  absolute EEDATH.2;
+  EEDATH_EEDATH1    : bit  absolute EEDATH.1;
+  EEDATH_EEDATH0    : bit  absolute EEDATH.0;
+  EEADRH            : byte absolute $010f;
+  EEADRH_EEADRH4    : bit  absolute EEADRH.4;
+  EEADRH_EEADRH3    : bit  absolute EEADRH.3;
+  EEADRH_EEADRH2    : bit  absolute EEADRH.2;
+  EEADRH_EEADRH1    : bit  absolute EEADRH.1;
+  EEADRH_EEADRH0    : bit  absolute EEADRH.0;
+  LCDDATA0          : byte absolute $0110;
+  LCDDATA0_SEG7     : bit  absolute LCDDATA0.7;
+  LCDDATA0_SEG6     : bit  absolute LCDDATA0.6;
+  LCDDATA0_SEG5     : bit  absolute LCDDATA0.5;
+  LCDDATA0_SEG4     : bit  absolute LCDDATA0.4;
+  LCDDATA0_SEG3     : bit  absolute LCDDATA0.3;
+  LCDDATA0_SEG2     : bit  absolute LCDDATA0.2;
+  LCDDATA0_SEG1     : bit  absolute LCDDATA0.1;
+  LCDDATA0_SEG0     : bit  absolute LCDDATA0.0;
+  LCDDATA1          : byte absolute $0111;
+  LCDDATA1_SEG15    : bit  absolute LCDDATA1.7;
+  LCDDATA1_SEG14    : bit  absolute LCDDATA1.6;
+  LCDDATA1_SEG13    : bit  absolute LCDDATA1.5;
+  LCDDATA1_SEG12    : bit  absolute LCDDATA1.4;
+  LCDDATA1_SEG11    : bit  absolute LCDDATA1.3;
+  LCDDATA1_SEG10    : bit  absolute LCDDATA1.2;
+  LCDDATA1_SEG9     : bit  absolute LCDDATA1.1;
+  LCDDATA1_SEG8     : bit  absolute LCDDATA1.0;
+  LCDDATA2          : byte absolute $0112;
+  LCDDATA2_SEG23    : bit  absolute LCDDATA2.7;
+  LCDDATA2_SEG22    : bit  absolute LCDDATA2.6;
+  LCDDATA2_SEG21    : bit  absolute LCDDATA2.5;
+  LCDDATA2_SEG20    : bit  absolute LCDDATA2.4;
+  LCDDATA2_SEG19    : bit  absolute LCDDATA2.3;
+  LCDDATA2_SEG18    : bit  absolute LCDDATA2.2;
+  LCDDATA2_SEG17    : bit  absolute LCDDATA2.1;
+  LCDDATA2_SEG16    : bit  absolute LCDDATA2.0;
+  LCDDATA3          : byte absolute $0113;
+  LCDDATA4          : byte absolute $0114;
+  LCDDATA5          : byte absolute $0115;
+  LCDDATA6          : byte absolute $0116;
+  LCDDATA7          : byte absolute $0117;
+  LCDDATA8          : byte absolute $0118;
+  LCDDATA9          : byte absolute $0119;
+  LCDDATA10         : byte absolute $011a;
+  LCDDATA11         : byte absolute $011b;
+  LCDSE0            : byte absolute $011c;
+  LCDSE1            : byte absolute $011d;
+  LCDSE2            : byte absolute $011e;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-099:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, ANSEL, PR2, SSPADD, SSPSTAT, WPUB, IOCB, CMCON1, TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09F:SFR'}  // CMCON0, VRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-11E:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, LCDCON, LCDPS, LVDCON, PCLATH, INTCON, EEDATL, EEADRL, EEDATH, EEADRH, LCDDATA0, LCDDATA1, LCDDATA2, LCDDATA3, LCDDATA4, LCDDATA5, LCDDATA6, LCDDATA7, LCDDATA8, LCDDATA9, LCDDATA10, LCDDATA11, LCDSE0, LCDSE1, LCDSE2
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '1F0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:F5'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:F5'} // PIE2
+  {$SET_UNIMP_BITS '08E:13'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '096:F0'} // IOCB
+  {$SET_UNIMP_BITS '097:03'} // CMCON1
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:AF'} // VRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:37'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/C1-/SEG12
+  // Pin  3 : RA1/AN1/C2-/SEG7
+  // Pin  4 : RA2/AN2/C2+/VREF-/COM2
+  // Pin  5 : RA3/AN3/C1+/VREF+/SEG15
+  // Pin  6 : RA4/C1OUT/T0CKI/SEG4
+  // Pin  7 : RA5/AN4/C2OUT/SS/SEG5
+  // Pin  8 : RE0/AN5/SEG21
+  // Pin  9 : RE1/AN6/SEG22
+  // Pin 10 : RE2/AN7/SEG23
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : RA7/OSC1/CLKIN/T1OSI
+  // Pin 14 : RA6/OSC2/CLKOUT/T1OSO
+  // Pin 15 : RC0/VLCD1
+  // Pin 16 : RC1/VLCD2
+  // Pin 17 : RC2/VLCD3
+  // Pin 18 : RC3/SEG6
+  // Pin 19 : RD0/COM3
+  // Pin 20 : RD1
+  // Pin 21 : RD2/CCP2
+  // Pin 22 : RD3/SEG16
+  // Pin 23 : RC4/T1G/SDO/SEG11
+  // Pin 24 : RC5/T1CKI/CCP1/SEG10
+  // Pin 25 : RC6/TX/CK/SCK/SCL/SEG9
+  // Pin 26 : RC7/RX/DT/SDI/SDA/SEG8
+  // Pin 27 : RD4/SEG17
+  // Pin 28 : RD5/SEG18
+  // Pin 29 : RD6/SEG19
+  // Pin 30 : RD7/SEG20
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT/SEG0
+  // Pin 34 : RB1/SEG1
+  // Pin 35 : RB2/SEG2
+  // Pin 36 : RB3/SEG3
+  // Pin 37 : RB4/COM0
+  // Pin 38 : RB5/COM1
+  // Pin 39 : RB6/ICSPCK/ICDCK/SEG14
+  // Pin 40 : RB7/ICSPDAT/ICDDAT/SEG13
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $1FFF}  // In-Circuit Debugger disabled, RB6/ISCPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $1FFE}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $1FEF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $1FE7}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $1FDF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $1F7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power Up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, CLKIN on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+
+implementation
+end.

--- a/PIC16F916.pas
+++ b/PIC16F916.pas
@@ -1,0 +1,524 @@
+unit PIC16F916;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F916'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_C2IF         : bit  absolute PIR2.5;
+  PIR2_C1IF         : bit  absolute PIR2.4;
+  PIR2_LCDIF        : bit  absolute PIR2.3;
+  PIR2_LVDIF        : bit  absolute PIR2.2;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GE        : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG1      : bit  absolute ADCON0.6;
+  ADCON0_VCFG0      : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_C2IE         : bit  absolute PIE2.5;
+  PIE2_C1IE         : bit  absolute PIE2.4;
+  PIE2_LCDIE        : bit  absolute PIE2.3;
+  PIE2_LVDIE        : bit  absolute PIE2.2;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  CMCON1            : byte absolute $0097;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON0            : byte absolute $009c;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  VRCON             : byte absolute $009d;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LCDCON            : byte absolute $0107;
+  LCDCON_LCDEN      : bit  absolute LCDCON.7;
+  LCDCON_SLPEN      : bit  absolute LCDCON.6;
+  LCDCON_WERR       : bit  absolute LCDCON.5;
+  LCDCON_VLCDEN     : bit  absolute LCDCON.4;
+  LCDCON_CS1        : bit  absolute LCDCON.3;
+  LCDCON_CS0        : bit  absolute LCDCON.2;
+  LCDCON_LMUX1      : bit  absolute LCDCON.1;
+  LCDCON_LMUX0      : bit  absolute LCDCON.0;
+  LCDPS             : byte absolute $0108;
+  LCDPS_WFT         : bit  absolute LCDPS.7;
+  LCDPS_BIASMD      : bit  absolute LCDPS.6;
+  LCDPS_LCDA        : bit  absolute LCDPS.5;
+  LCDPS_WA          : bit  absolute LCDPS.4;
+  LCDPS_LP3         : bit  absolute LCDPS.3;
+  LCDPS_LP2         : bit  absolute LCDPS.2;
+  LCDPS_LP1         : bit  absolute LCDPS.1;
+  LCDPS_LP0         : bit  absolute LCDPS.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  EEDATL            : byte absolute $010c;
+  EEDATL_EEDATL7    : bit  absolute EEDATL.7;
+  EEDATL_EEDATL6    : bit  absolute EEDATL.6;
+  EEDATL_EEDATL5    : bit  absolute EEDATL.5;
+  EEDATL_EEDATL4    : bit  absolute EEDATL.4;
+  EEDATL_EEDATL3    : bit  absolute EEDATL.3;
+  EEDATL_EEDATL2    : bit  absolute EEDATL.2;
+  EEDATL_EEDATL1    : bit  absolute EEDATL.1;
+  EEDATL_EEDATL0    : bit  absolute EEDATL.0;
+  EEADRL            : byte absolute $010d;
+  EEADRL_EEADRL7    : bit  absolute EEADRL.7;
+  EEADRL_EEADRL6    : bit  absolute EEADRL.6;
+  EEADRL_EEADRL5    : bit  absolute EEADRL.5;
+  EEADRL_EEADRL4    : bit  absolute EEADRL.4;
+  EEADRL_EEADRL3    : bit  absolute EEADRL.3;
+  EEADRL_EEADRL2    : bit  absolute EEADRL.2;
+  EEADRL_EEADRL1    : bit  absolute EEADRL.1;
+  EEADRL_EEADRL0    : bit  absolute EEADRL.0;
+  EEDATH            : byte absolute $010e;
+  EEDATH_EEDATH5    : bit  absolute EEDATH.5;
+  EEDATH_EEDATH4    : bit  absolute EEDATH.4;
+  EEDATH_EEDATH3    : bit  absolute EEDATH.3;
+  EEDATH_EEDATH2    : bit  absolute EEDATH.2;
+  EEDATH_EEDATH1    : bit  absolute EEDATH.1;
+  EEDATH_EEDATH0    : bit  absolute EEDATH.0;
+  EEADRH            : byte absolute $010f;
+  EEADRH_EEADRH4    : bit  absolute EEADRH.4;
+  EEADRH_EEADRH3    : bit  absolute EEADRH.3;
+  EEADRH_EEADRH2    : bit  absolute EEADRH.2;
+  EEADRH_EEADRH1    : bit  absolute EEADRH.1;
+  EEADRH_EEADRH0    : bit  absolute EEADRH.0;
+  LCDDATA0          : byte absolute $0110;
+  LCDDATA0_SEG7     : bit  absolute LCDDATA0.7;
+  LCDDATA0_SEG6     : bit  absolute LCDDATA0.6;
+  LCDDATA0_SEG5     : bit  absolute LCDDATA0.5;
+  LCDDATA0_SEG4     : bit  absolute LCDDATA0.4;
+  LCDDATA0_SEG3     : bit  absolute LCDDATA0.3;
+  LCDDATA0_SEG2     : bit  absolute LCDDATA0.2;
+  LCDDATA0_SEG1     : bit  absolute LCDDATA0.1;
+  LCDDATA0_SEG0     : bit  absolute LCDDATA0.0;
+  LCDDATA1          : byte absolute $0111;
+  LCDDATA1_SEG15    : bit  absolute LCDDATA1.7;
+  LCDDATA1_SEG14    : bit  absolute LCDDATA1.6;
+  LCDDATA1_SEG13    : bit  absolute LCDDATA1.5;
+  LCDDATA1_SEG12    : bit  absolute LCDDATA1.4;
+  LCDDATA1_SEG11    : bit  absolute LCDDATA1.3;
+  LCDDATA1_SEG10    : bit  absolute LCDDATA1.2;
+  LCDDATA1_SEG9     : bit  absolute LCDDATA1.1;
+  LCDDATA1_SEG8     : bit  absolute LCDDATA1.0;
+  LCDDATA3          : byte absolute $0113;
+  LCDDATA4          : byte absolute $0114;
+  LCDDATA6          : byte absolute $0116;
+  LCDDATA7          : byte absolute $0117;
+  LCDDATA9          : byte absolute $0119;
+  LCDDATA10         : byte absolute $011a;
+  LCDSE0            : byte absolute $011c;
+  LCDSE1            : byte absolute $011d;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '009-01A:SFR'}  // PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG
+  {$SET_STATE_RAM '01E-01F:SFR'}  // ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-087:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC
+  {$SET_STATE_RAM '089-099:SFR'}  // TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, ANSEL, PR2, SSPADD, SSPSTAT, WPUB, IOCB, CMCON1, TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09F:SFR'}  // CMCON0, VRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-111:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, LCDCON, LCDPS, LVDCON, PCLATH, INTCON, EEDATL, EEADRL, EEDATH, EEADRH, LCDDATA0, LCDDATA1
+  {$SET_STATE_RAM '113-114:SFR'}  // LCDDATA3, LCDDATA4
+  {$SET_STATE_RAM '116-117:SFR'}  // LCDDATA6, LCDDATA7
+  {$SET_STATE_RAM '119-11A:SFR'}  // LCDDATA9, LCDDATA10
+  {$SET_STATE_RAM '11C-11D:SFR'}  // LCDSE0, LCDSE1
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:08'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:F4'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '089:08'} // TRISE
+  {$SET_UNIMP_BITS '08D:F4'} // PIE2
+  {$SET_UNIMP_BITS '08E:13'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '091:1F'} // ANSEL
+  {$SET_UNIMP_BITS '096:F0'} // IOCB
+  {$SET_UNIMP_BITS '097:03'} // CMCON1
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:AF'} // VRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:37'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/C1-/SEG12
+  // Pin  3 : RA1/AN1/C2-/SEG7
+  // Pin  4 : RA2/AN2/C2+/VREF-/COM2
+  // Pin  5 : RA3/AN3/C1+/VREF+/COM3/SEG15
+  // Pin  6 : RA4/C1OUT/T0CKI/SEG4
+  // Pin  7 : RA5/AN4/C2OUT/SS/SEG5
+  // Pin  8 : Vss
+  // Pin  9 : RA7/OSC1/CLKIN/T1OSI
+  // Pin 10 : RA6/OSC2/CLKOUT/T1OSO
+  // Pin 11 : RC0/VLCD1
+  // Pin 12 : RC1/VLCD2
+  // Pin 13 : RC2/VLCD3
+  // Pin 14 : RC3/SEG6
+  // Pin 15 : RC4/T1G/SDO/SEG11
+  // Pin 16 : RC5/T1CKI/CCP1/SEG10
+  // Pin 17 : RC6/TX/CK/SCK/SCL/SEG9
+  // Pin 18 : RC7/RX/DT/SDI/SDA/SEG8
+  // Pin 19 : Vss
+  // Pin 20 : Vdd
+  // Pin 21 : RB0/INT/SEG0
+  // Pin 22 : RB1/SEG1
+  // Pin 23 : RB2/SEG2
+  // Pin 24 : RB3/SEG3
+  // Pin 25 : RB4/COM0
+  // Pin 26 : RB5/COM1
+  // Pin 27 : RB6/ICSPCK/ICDCK/SEG14
+  // Pin 28 : RB7/ICSPDAT/ICDDAT/SEG13
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+  {$MAP_RAM_TO_PIN '009:3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $1FFF}  // In-Circuit Debugger disabled, RB6/ISCPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $1FFE}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $1FEF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $1FE7}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $1FDF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $1F7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power Up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, CLKIN on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+
+implementation
+end.

--- a/PIC16F917.pas
+++ b/PIC16F917.pas
@@ -1,0 +1,581 @@
+unit PIC16F917;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F917'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_C2IF         : bit  absolute PIR2.5;
+  PIR2_C1IF         : bit  absolute PIR2.4;
+  PIR2_LCDIF        : bit  absolute PIR2.3;
+  PIR2_LVDIF        : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GE        : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG1      : bit  absolute ADCON0.6;
+  ADCON0_VCFG0      : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_C2IE         : bit  absolute PIE2.5;
+  PIE2_C1IE         : bit  absolute PIE2.4;
+  PIE2_LCDIE        : bit  absolute PIE2.3;
+  PIE2_LVDIE        : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  CMCON1            : byte absolute $0097;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON0            : byte absolute $009c;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  VRCON             : byte absolute $009d;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LCDCON            : byte absolute $0107;
+  LCDCON_LCDEN      : bit  absolute LCDCON.7;
+  LCDCON_SLPEN      : bit  absolute LCDCON.6;
+  LCDCON_WERR       : bit  absolute LCDCON.5;
+  LCDCON_VLCDEN     : bit  absolute LCDCON.4;
+  LCDCON_CS1        : bit  absolute LCDCON.3;
+  LCDCON_CS0        : bit  absolute LCDCON.2;
+  LCDCON_LMUX1      : bit  absolute LCDCON.1;
+  LCDCON_LMUX0      : bit  absolute LCDCON.0;
+  LCDPS             : byte absolute $0108;
+  LCDPS_WFT         : bit  absolute LCDPS.7;
+  LCDPS_BIASMD      : bit  absolute LCDPS.6;
+  LCDPS_LCDA        : bit  absolute LCDPS.5;
+  LCDPS_WA          : bit  absolute LCDPS.4;
+  LCDPS_LP3         : bit  absolute LCDPS.3;
+  LCDPS_LP2         : bit  absolute LCDPS.2;
+  LCDPS_LP1         : bit  absolute LCDPS.1;
+  LCDPS_LP0         : bit  absolute LCDPS.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  EEDATL            : byte absolute $010c;
+  EEDATL_EEDATL7    : bit  absolute EEDATL.7;
+  EEDATL_EEDATL6    : bit  absolute EEDATL.6;
+  EEDATL_EEDATL5    : bit  absolute EEDATL.5;
+  EEDATL_EEDATL4    : bit  absolute EEDATL.4;
+  EEDATL_EEDATL3    : bit  absolute EEDATL.3;
+  EEDATL_EEDATL2    : bit  absolute EEDATL.2;
+  EEDATL_EEDATL1    : bit  absolute EEDATL.1;
+  EEDATL_EEDATL0    : bit  absolute EEDATL.0;
+  EEADRL            : byte absolute $010d;
+  EEADRL_EEADRL7    : bit  absolute EEADRL.7;
+  EEADRL_EEADRL6    : bit  absolute EEADRL.6;
+  EEADRL_EEADRL5    : bit  absolute EEADRL.5;
+  EEADRL_EEADRL4    : bit  absolute EEADRL.4;
+  EEADRL_EEADRL3    : bit  absolute EEADRL.3;
+  EEADRL_EEADRL2    : bit  absolute EEADRL.2;
+  EEADRL_EEADRL1    : bit  absolute EEADRL.1;
+  EEADRL_EEADRL0    : bit  absolute EEADRL.0;
+  EEDATH            : byte absolute $010e;
+  EEDATH_EEDATH5    : bit  absolute EEDATH.5;
+  EEDATH_EEDATH4    : bit  absolute EEDATH.4;
+  EEDATH_EEDATH3    : bit  absolute EEDATH.3;
+  EEDATH_EEDATH2    : bit  absolute EEDATH.2;
+  EEDATH_EEDATH1    : bit  absolute EEDATH.1;
+  EEDATH_EEDATH0    : bit  absolute EEDATH.0;
+  EEADRH            : byte absolute $010f;
+  EEADRH_EEADRH4    : bit  absolute EEADRH.4;
+  EEADRH_EEADRH3    : bit  absolute EEADRH.3;
+  EEADRH_EEADRH2    : bit  absolute EEADRH.2;
+  EEADRH_EEADRH1    : bit  absolute EEADRH.1;
+  EEADRH_EEADRH0    : bit  absolute EEADRH.0;
+  LCDDATA0          : byte absolute $0110;
+  LCDDATA0_SEG7     : bit  absolute LCDDATA0.7;
+  LCDDATA0_SEG6     : bit  absolute LCDDATA0.6;
+  LCDDATA0_SEG5     : bit  absolute LCDDATA0.5;
+  LCDDATA0_SEG4     : bit  absolute LCDDATA0.4;
+  LCDDATA0_SEG3     : bit  absolute LCDDATA0.3;
+  LCDDATA0_SEG2     : bit  absolute LCDDATA0.2;
+  LCDDATA0_SEG1     : bit  absolute LCDDATA0.1;
+  LCDDATA0_SEG0     : bit  absolute LCDDATA0.0;
+  LCDDATA1          : byte absolute $0111;
+  LCDDATA1_SEG15    : bit  absolute LCDDATA1.7;
+  LCDDATA1_SEG14    : bit  absolute LCDDATA1.6;
+  LCDDATA1_SEG13    : bit  absolute LCDDATA1.5;
+  LCDDATA1_SEG12    : bit  absolute LCDDATA1.4;
+  LCDDATA1_SEG11    : bit  absolute LCDDATA1.3;
+  LCDDATA1_SEG10    : bit  absolute LCDDATA1.2;
+  LCDDATA1_SEG9     : bit  absolute LCDDATA1.1;
+  LCDDATA1_SEG8     : bit  absolute LCDDATA1.0;
+  LCDDATA2          : byte absolute $0112;
+  LCDDATA2_SEG23    : bit  absolute LCDDATA2.7;
+  LCDDATA2_SEG22    : bit  absolute LCDDATA2.6;
+  LCDDATA2_SEG21    : bit  absolute LCDDATA2.5;
+  LCDDATA2_SEG20    : bit  absolute LCDDATA2.4;
+  LCDDATA2_SEG19    : bit  absolute LCDDATA2.3;
+  LCDDATA2_SEG18    : bit  absolute LCDDATA2.2;
+  LCDDATA2_SEG17    : bit  absolute LCDDATA2.1;
+  LCDDATA2_SEG16    : bit  absolute LCDDATA2.0;
+  LCDDATA3          : byte absolute $0113;
+  LCDDATA4          : byte absolute $0114;
+  LCDDATA5          : byte absolute $0115;
+  LCDDATA6          : byte absolute $0116;
+  LCDDATA7          : byte absolute $0117;
+  LCDDATA8          : byte absolute $0118;
+  LCDDATA9          : byte absolute $0119;
+  LCDDATA10         : byte absolute $011a;
+  LCDDATA11         : byte absolute $011b;
+  LCDSE0            : byte absolute $011c;
+  LCDSE1            : byte absolute $011d;
+  LCDSE2            : byte absolute $011e;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-099:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, ANSEL, PR2, SSPADD, SSPSTAT, WPUB, IOCB, CMCON1, TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09F:SFR'}  // CMCON0, VRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-11E:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, LCDCON, LCDPS, LVDCON, PCLATH, INTCON, EEDATL, EEADRL, EEDATH, EEADRH, LCDDATA0, LCDDATA1, LCDDATA2, LCDDATA3, LCDDATA4, LCDDATA5, LCDDATA6, LCDDATA7, LCDDATA8, LCDDATA9, LCDDATA10, LCDDATA11, LCDSE0, LCDSE1, LCDSE2
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-184:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR
+  {$SET_STATE_RAM '186-186:SFR'}  // TRISB
+  {$SET_STATE_RAM '18A-18D:SFR'}  // PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '009:0F'} // PORTE
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:F5'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '089:0F'} // TRISE
+  {$SET_UNIMP_BITS '08D:F5'} // PIE2
+  {$SET_UNIMP_BITS '08E:13'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '096:F0'} // IOCB
+  {$SET_UNIMP_BITS '097:03'} // CMCON1
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:AF'} // VRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:37'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RE3/MCLR/Vpp
+  // Pin  2 : RA0/AN0/C1-/SEG12
+  // Pin  3 : RA1/AN1/C2-/SEG7
+  // Pin  4 : RA2/AN2/C2+/VREF-/COM2
+  // Pin  5 : RA3/AN3/C1+/VREF+/SEG15
+  // Pin  6 : RA4/C1OUT/T0CKI/SEG4
+  // Pin  7 : RA5/AN4/C2OUT/SS/SEG5
+  // Pin  8 : RE0/AN5/SEG21
+  // Pin  9 : RE1/AN6/SEG22
+  // Pin 10 : RE2/AN7/SEG23
+  // Pin 11 : Vdd
+  // Pin 12 : Vss
+  // Pin 13 : RA7/OSC1/CLKIN/T1OSI
+  // Pin 14 : RA6/OSC2/CLKOUT/T1OSO
+  // Pin 15 : RC0/VLCD1
+  // Pin 16 : RC1/VLCD2
+  // Pin 17 : RC2/VLCD3
+  // Pin 18 : RC3/SEG6
+  // Pin 19 : RD0/COM3
+  // Pin 20 : RD1
+  // Pin 21 : RD2/CCP2
+  // Pin 22 : RD3/SEG16
+  // Pin 23 : RC4/T1G/SDO/SEG11
+  // Pin 24 : RC5/T1CKI/CCP1/SEG10
+  // Pin 25 : RC6/TX/CK/SCK/SCL/SEG9
+  // Pin 26 : RC7/RX/DT/SDI/SDA/SEG8
+  // Pin 27 : RD4/SEG17
+  // Pin 28 : RD5/SEG18
+  // Pin 29 : RD6/SEG19
+  // Pin 30 : RD7/SEG20
+  // Pin 31 : Vss
+  // Pin 32 : Vdd
+  // Pin 33 : RB0/INT/SEG0
+  // Pin 34 : RB1/SEG1
+  // Pin 35 : RB2/SEG2
+  // Pin 36 : RB3/SEG3
+  // Pin 37 : RB4/COM0
+  // Pin 38 : RB5/COM1
+  // Pin 39 : RB6/ICSPCK/ICDCK/SEG14
+  // Pin 40 : RB7/ICSPDAT/ICDDAT/SEG13
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-2,1-3,2-4,3-5,4-6,5-7,6-14,7-13'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-33,1-34,2-35,3-36,4-37,5-38,6-39,7-40'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-15,1-16,2-17,3-18,4-23,5-24,6-25,7-26'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-19,1-20,2-21,3-22,4-27,5-28,6-29,7-30'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-8,1-9,2-10,3-1'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $1FFF}  // In-Circuit Debugger disabled, RB6/ISCPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $1FFE}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $1FEF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $1FE7}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $1FDF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $1F7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power Up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, CLKIN on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+
+implementation
+end.

--- a/PIC16F946.pas
+++ b/PIC16F946.pas
@@ -1,0 +1,684 @@
+unit PIC16F946;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F946'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 64}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 8192}
+
+interface
+var
+  INDF              : byte absolute $0000;
+  TMR0              : byte absolute $0001;
+  PCL               : byte absolute $0002;
+  STATUS            : byte absolute $0003;
+  STATUS_IRP        : bit  absolute STATUS.7;
+  STATUS_RP1        : bit  absolute STATUS.6;
+  STATUS_RP0        : bit  absolute STATUS.5;
+  STATUS_TO         : bit  absolute STATUS.4;
+  STATUS_PD         : bit  absolute STATUS.3;
+  STATUS_Z          : bit  absolute STATUS.2;
+  STATUS_DC         : bit  absolute STATUS.1;
+  STATUS_C          : bit  absolute STATUS.0;
+  FSR               : byte absolute $0004;
+  PORTA             : byte absolute $0005;
+  PORTA_RA7         : bit  absolute PORTA.7;
+  PORTA_RA6         : bit  absolute PORTA.6;
+  PORTA_RA5         : bit  absolute PORTA.5;
+  PORTA_RA4         : bit  absolute PORTA.4;
+  PORTA_RA3         : bit  absolute PORTA.3;
+  PORTA_RA2         : bit  absolute PORTA.2;
+  PORTA_RA1         : bit  absolute PORTA.1;
+  PORTA_RA0         : bit  absolute PORTA.0;
+  PORTB             : byte absolute $0006;
+  PORTB_RB7         : bit  absolute PORTB.7;
+  PORTB_RB6         : bit  absolute PORTB.6;
+  PORTB_RB5         : bit  absolute PORTB.5;
+  PORTB_RB4         : bit  absolute PORTB.4;
+  PORTB_RB3         : bit  absolute PORTB.3;
+  PORTB_RB2         : bit  absolute PORTB.2;
+  PORTB_RB1         : bit  absolute PORTB.1;
+  PORTB_RB0         : bit  absolute PORTB.0;
+  PORTC             : byte absolute $0007;
+  PORTC_RC7         : bit  absolute PORTC.7;
+  PORTC_RC6         : bit  absolute PORTC.6;
+  PORTC_RC5         : bit  absolute PORTC.5;
+  PORTC_RC4         : bit  absolute PORTC.4;
+  PORTC_RC3         : bit  absolute PORTC.3;
+  PORTC_RC2         : bit  absolute PORTC.2;
+  PORTC_RC1         : bit  absolute PORTC.1;
+  PORTC_RC0         : bit  absolute PORTC.0;
+  PORTD             : byte absolute $0008;
+  PORTD_RD7         : bit  absolute PORTD.7;
+  PORTD_RD6         : bit  absolute PORTD.6;
+  PORTD_RD5         : bit  absolute PORTD.5;
+  PORTD_RD4         : bit  absolute PORTD.4;
+  PORTD_RD3         : bit  absolute PORTD.3;
+  PORTD_RD2         : bit  absolute PORTD.2;
+  PORTD_RD1         : bit  absolute PORTD.1;
+  PORTD_RD0         : bit  absolute PORTD.0;
+  PORTE             : byte absolute $0009;
+  PORTE_RE7         : bit  absolute PORTE.7;
+  PORTE_RE6         : bit  absolute PORTE.6;
+  PORTE_RE5         : bit  absolute PORTE.5;
+  PORTE_RE4         : bit  absolute PORTE.4;
+  PORTE_RE3         : bit  absolute PORTE.3;
+  PORTE_RE2         : bit  absolute PORTE.2;
+  PORTE_RE1         : bit  absolute PORTE.1;
+  PORTE_RE0         : bit  absolute PORTE.0;
+  PCLATH            : byte absolute $000a;
+  INTCON            : byte absolute $000b;
+  INTCON_GIE        : bit  absolute INTCON.7;
+  INTCON_PEIE       : bit  absolute INTCON.6;
+  INTCON_TMR0IE     : bit  absolute INTCON.5;
+  INTCON_INTE       : bit  absolute INTCON.4;
+  INTCON_RBIE       : bit  absolute INTCON.3;
+  INTCON_TMR0IF     : bit  absolute INTCON.2;
+  INTCON_INTF       : bit  absolute INTCON.1;
+  INTCON_RBIF       : bit  absolute INTCON.0;
+  PIR1              : byte absolute $000c;
+  PIR1_EEIF         : bit  absolute PIR1.7;
+  PIR1_ADIF         : bit  absolute PIR1.6;
+  PIR1_RCIF         : bit  absolute PIR1.5;
+  PIR1_TXIF         : bit  absolute PIR1.4;
+  PIR1_SSPIF        : bit  absolute PIR1.3;
+  PIR1_CCP1IF       : bit  absolute PIR1.2;
+  PIR1_TMR2IF       : bit  absolute PIR1.1;
+  PIR1_TMR1IF       : bit  absolute PIR1.0;
+  PIR2              : byte absolute $000d;
+  PIR2_OSFIF        : bit  absolute PIR2.6;
+  PIR2_C2IF         : bit  absolute PIR2.5;
+  PIR2_C1IF         : bit  absolute PIR2.4;
+  PIR2_LCDIF        : bit  absolute PIR2.3;
+  PIR2_LVDIF        : bit  absolute PIR2.2;
+  PIR2_CCP2IF       : bit  absolute PIR2.1;
+  TMR1L             : byte absolute $000e;
+  TMR1H             : byte absolute $000f;
+  T1CON             : byte absolute $0010;
+  T1CON_T1GINV      : bit  absolute T1CON.7;
+  T1CON_TMR1GE      : bit  absolute T1CON.6;
+  T1CON_T1GE        : bit  absolute T1CON.5;
+  T1CON_T1CKPS1     : bit  absolute T1CON.4;
+  T1CON_T1OSCEN     : bit  absolute T1CON.3;
+  T1CON_T1SYNC      : bit  absolute T1CON.2;
+  T1CON_TMR1CS      : bit  absolute T1CON.1;
+  T1CON_TMR1ON      : bit  absolute T1CON.0;
+  TMR2              : byte absolute $0011;
+  T2CON             : byte absolute $0012;
+  T2CON_TOUTPS3     : bit  absolute T2CON.6;
+  T2CON_TOUTPS2     : bit  absolute T2CON.5;
+  T2CON_TOUTPS1     : bit  absolute T2CON.4;
+  T2CON_TOUTPS0     : bit  absolute T2CON.3;
+  T2CON_TMR2ON      : bit  absolute T2CON.2;
+  T2CON_T2CKPS0     : bit  absolute T2CON.1;
+  SSPBUF            : byte absolute $0013;
+  SSPCON            : byte absolute $0014;
+  SSPCON_WCOL       : bit  absolute SSPCON.7;
+  SSPCON_SSPOV      : bit  absolute SSPCON.6;
+  SSPCON_SSPEN      : bit  absolute SSPCON.5;
+  SSPCON_CKP        : bit  absolute SSPCON.4;
+  SSPCON_SSPM3      : bit  absolute SSPCON.3;
+  SSPCON_SSPM2      : bit  absolute SSPCON.2;
+  SSPCON_SSPM1      : bit  absolute SSPCON.1;
+  SSPCON_SSPM0      : bit  absolute SSPCON.0;
+  CCPR1L            : byte absolute $0015;
+  CCPR1H            : byte absolute $0016;
+  CCP1CON           : byte absolute $0017;
+  CCP1CON_CCP1X     : bit  absolute CCP1CON.5;
+  CCP1CON_CCP1Y     : bit  absolute CCP1CON.4;
+  CCP1CON_CCP1M3    : bit  absolute CCP1CON.3;
+  CCP1CON_CCP1M2    : bit  absolute CCP1CON.2;
+  CCP1CON_CCP1M1    : bit  absolute CCP1CON.1;
+  CCP1CON_CCP1M0    : bit  absolute CCP1CON.0;
+  RCSTA             : byte absolute $0018;
+  RCSTA_SPEN        : bit  absolute RCSTA.7;
+  RCSTA_RX9         : bit  absolute RCSTA.6;
+  RCSTA_SREN        : bit  absolute RCSTA.5;
+  RCSTA_CREN        : bit  absolute RCSTA.4;
+  RCSTA_ADDEN       : bit  absolute RCSTA.3;
+  RCSTA_FERR        : bit  absolute RCSTA.2;
+  RCSTA_OERR        : bit  absolute RCSTA.1;
+  RCSTA_RX9D        : bit  absolute RCSTA.0;
+  TXREG             : byte absolute $0019;
+  RCREG             : byte absolute $001a;
+  CCPR2L            : byte absolute $001b;
+  CCPR2H            : byte absolute $001c;
+  CCP2CON           : byte absolute $001d;
+  CCP2CON_CCP2X     : bit  absolute CCP2CON.5;
+  CCP2CON_CCP2Y     : bit  absolute CCP2CON.4;
+  CCP2CON_CCP2M3    : bit  absolute CCP2CON.3;
+  CCP2CON_CCP2M2    : bit  absolute CCP2CON.2;
+  CCP2CON_CCP2M1    : bit  absolute CCP2CON.1;
+  CCP2CON_CCP2M0    : bit  absolute CCP2CON.0;
+  ADRESH            : byte absolute $001e;
+  ADCON0            : byte absolute $001f;
+  ADCON0_ADFM       : bit  absolute ADCON0.7;
+  ADCON0_VCFG1      : bit  absolute ADCON0.6;
+  ADCON0_VCFG0      : bit  absolute ADCON0.5;
+  ADCON0_CHS2       : bit  absolute ADCON0.4;
+  ADCON0_CHS1       : bit  absolute ADCON0.3;
+  ADCON0_CHS0       : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE   : bit  absolute ADCON0.1;
+  ADCON0_ADON       : bit  absolute ADCON0.0;
+  OPTION_REG        : byte absolute $0081;
+  OPTION_REG_RBPU   : bit  absolute OPTION_REG.7;
+  OPTION_REG_INTEDG : bit  absolute OPTION_REG.6;
+  OPTION_REG_T0CS   : bit  absolute OPTION_REG.5;
+  OPTION_REG_T0SE   : bit  absolute OPTION_REG.4;
+  OPTION_REG_PSA    : bit  absolute OPTION_REG.3;
+  OPTION_REG_PS2    : bit  absolute OPTION_REG.2;
+  OPTION_REG_PS1    : bit  absolute OPTION_REG.1;
+  OPTION_REG_PS0    : bit  absolute OPTION_REG.0;
+  TRISA             : byte absolute $0085;
+  TRISA_TRISA7      : bit  absolute TRISA.7;
+  TRISA_TRISA6      : bit  absolute TRISA.6;
+  TRISA_TRISA5      : bit  absolute TRISA.5;
+  TRISA_TRISA4      : bit  absolute TRISA.4;
+  TRISA_TRISA3      : bit  absolute TRISA.3;
+  TRISA_TRISA2      : bit  absolute TRISA.2;
+  TRISA_TRISA1      : bit  absolute TRISA.1;
+  TRISA_TRISA0      : bit  absolute TRISA.0;
+  TRISB             : byte absolute $0086;
+  TRISB_TRISB7      : bit  absolute TRISB.7;
+  TRISB_TRISB6      : bit  absolute TRISB.6;
+  TRISB_TRISB5      : bit  absolute TRISB.5;
+  TRISB_TRISB4      : bit  absolute TRISB.4;
+  TRISB_TRISB3      : bit  absolute TRISB.3;
+  TRISB_TRISB2      : bit  absolute TRISB.2;
+  TRISB_TRISB1      : bit  absolute TRISB.1;
+  TRISB_TRISB0      : bit  absolute TRISB.0;
+  TRISC             : byte absolute $0087;
+  TRISC_TRISC7      : bit  absolute TRISC.7;
+  TRISC_TRISC6      : bit  absolute TRISC.6;
+  TRISC_TRISC5      : bit  absolute TRISC.5;
+  TRISC_TRISC4      : bit  absolute TRISC.4;
+  TRISC_TRISC3      : bit  absolute TRISC.3;
+  TRISC_TRISC2      : bit  absolute TRISC.2;
+  TRISC_TRISC1      : bit  absolute TRISC.1;
+  TRISC_TRISC0      : bit  absolute TRISC.0;
+  TRISD             : byte absolute $0088;
+  TRISD_TRISD7      : bit  absolute TRISD.7;
+  TRISD_TRISD6      : bit  absolute TRISD.6;
+  TRISD_TRISD5      : bit  absolute TRISD.5;
+  TRISD_TRISD4      : bit  absolute TRISD.4;
+  TRISD_TRISD3      : bit  absolute TRISD.3;
+  TRISD_TRISD2      : bit  absolute TRISD.2;
+  TRISD_TRISD1      : bit  absolute TRISD.1;
+  TRISD_TRISD0      : bit  absolute TRISD.0;
+  TRISE             : byte absolute $0089;
+  TRISE_TRISE7      : bit  absolute TRISE.7;
+  TRISE_TRISE6      : bit  absolute TRISE.6;
+  TRISE_TRISE5      : bit  absolute TRISE.5;
+  TRISE_TRISE4      : bit  absolute TRISE.4;
+  TRISE_TRISE3      : bit  absolute TRISE.3;
+  TRISE_TRISE2      : bit  absolute TRISE.2;
+  TRISE_TRISE1      : bit  absolute TRISE.1;
+  TRISE_TRISE0      : bit  absolute TRISE.0;
+  PIE1              : byte absolute $008c;
+  PIE1_EEIE         : bit  absolute PIE1.7;
+  PIE1_ADIE         : bit  absolute PIE1.6;
+  PIE1_RCIE         : bit  absolute PIE1.5;
+  PIE1_TXIE         : bit  absolute PIE1.4;
+  PIE1_SSPIE        : bit  absolute PIE1.3;
+  PIE1_CCP1IE       : bit  absolute PIE1.2;
+  PIE1_TMR2IE       : bit  absolute PIE1.1;
+  PIE1_TMR1IE       : bit  absolute PIE1.0;
+  PIE2              : byte absolute $008d;
+  PIE2_OSFIE        : bit  absolute PIE2.6;
+  PIE2_C2IE         : bit  absolute PIE2.5;
+  PIE2_C1IE         : bit  absolute PIE2.4;
+  PIE2_LCDIE        : bit  absolute PIE2.3;
+  PIE2_LVDIE        : bit  absolute PIE2.2;
+  PIE2_CCP2IE       : bit  absolute PIE2.1;
+  PCON              : byte absolute $008e;
+  PCON_SBOREN       : bit  absolute PCON.4;
+  PCON_POR          : bit  absolute PCON.3;
+  PCON_BOR          : bit  absolute PCON.2;
+  OSCCON            : byte absolute $008f;
+  OSCCON_IRCF2      : bit  absolute OSCCON.6;
+  OSCCON_IRCF1      : bit  absolute OSCCON.5;
+  OSCCON_IRCF0      : bit  absolute OSCCON.4;
+  OSCCON_OSTS       : bit  absolute OSCCON.3;
+  OSCCON_HTS        : bit  absolute OSCCON.2;
+  OSCCON_LTS        : bit  absolute OSCCON.1;
+  OSCCON_SCS        : bit  absolute OSCCON.0;
+  OSCTUNE           : byte absolute $0090;
+  OSCTUNE_TUN4      : bit  absolute OSCTUNE.4;
+  OSCTUNE_TUN3      : bit  absolute OSCTUNE.3;
+  OSCTUNE_TUN2      : bit  absolute OSCTUNE.2;
+  OSCTUNE_TUN1      : bit  absolute OSCTUNE.1;
+  OSCTUNE_TUN0      : bit  absolute OSCTUNE.0;
+  ANSEL             : byte absolute $0091;
+  ANSEL_ANS7        : bit  absolute ANSEL.7;
+  ANSEL_ANS6        : bit  absolute ANSEL.6;
+  ANSEL_ANS5        : bit  absolute ANSEL.5;
+  ANSEL_ANS4        : bit  absolute ANSEL.4;
+  ANSEL_ANS3        : bit  absolute ANSEL.3;
+  ANSEL_ANS2        : bit  absolute ANSEL.2;
+  ANSEL_ANS1        : bit  absolute ANSEL.1;
+  ANSEL_ANS0        : bit  absolute ANSEL.0;
+  PR2               : byte absolute $0092;
+  SSPADD            : byte absolute $0093;
+  SSPSTAT           : byte absolute $0094;
+  SSPSTAT_SMP       : bit  absolute SSPSTAT.7;
+  SSPSTAT_CKE       : bit  absolute SSPSTAT.6;
+  SSPSTAT_D_nA      : bit  absolute SSPSTAT.5;
+  SSPSTAT_P         : bit  absolute SSPSTAT.4;
+  SSPSTAT_S         : bit  absolute SSPSTAT.3;
+  SSPSTAT_R_nW      : bit  absolute SSPSTAT.2;
+  SSPSTAT_UA        : bit  absolute SSPSTAT.1;
+  SSPSTAT_BF        : bit  absolute SSPSTAT.0;
+  WPUB              : byte absolute $0095;
+  WPUB_WPUB7        : bit  absolute WPUB.7;
+  WPUB_WPUB6        : bit  absolute WPUB.6;
+  WPUB_WPUB5        : bit  absolute WPUB.5;
+  WPUB_WPUB4        : bit  absolute WPUB.4;
+  WPUB_WPUB3        : bit  absolute WPUB.3;
+  WPUB_WPUB2        : bit  absolute WPUB.2;
+  WPUB_WPUB1        : bit  absolute WPUB.1;
+  WPUB_WPUB0        : bit  absolute WPUB.0;
+  IOCB              : byte absolute $0096;
+  IOCB_IOCB7        : bit  absolute IOCB.7;
+  IOCB_IOCB6        : bit  absolute IOCB.6;
+  IOCB_IOCB5        : bit  absolute IOCB.5;
+  IOCB_IOCB4        : bit  absolute IOCB.4;
+  CMCON1            : byte absolute $0097;
+  CMCON1_T1GSS      : bit  absolute CMCON1.1;
+  CMCON1_C2SYNC     : bit  absolute CMCON1.0;
+  TXSTA             : byte absolute $0098;
+  TXSTA_CSRC        : bit  absolute TXSTA.7;
+  TXSTA_TX9         : bit  absolute TXSTA.6;
+  TXSTA_TXEN        : bit  absolute TXSTA.5;
+  TXSTA_SYNC        : bit  absolute TXSTA.4;
+  TXSTA_BRGH        : bit  absolute TXSTA.3;
+  TXSTA_TRMT        : bit  absolute TXSTA.2;
+  TXSTA_TX9D        : bit  absolute TXSTA.1;
+  SPBRG             : byte absolute $0099;
+  CMCON0            : byte absolute $009c;
+  CMCON0_C2OUT      : bit  absolute CMCON0.7;
+  CMCON0_C1OUT      : bit  absolute CMCON0.6;
+  CMCON0_C2INV      : bit  absolute CMCON0.5;
+  CMCON0_C1INV      : bit  absolute CMCON0.4;
+  CMCON0_CIS        : bit  absolute CMCON0.3;
+  CMCON0_CM2        : bit  absolute CMCON0.2;
+  CMCON0_CM1        : bit  absolute CMCON0.1;
+  CMCON0_CM0        : bit  absolute CMCON0.0;
+  VRCON             : byte absolute $009d;
+  VRCON_VREN        : bit  absolute VRCON.6;
+  VRCON_VRR         : bit  absolute VRCON.5;
+  VRCON_VR3         : bit  absolute VRCON.3;
+  VRCON_VR2         : bit  absolute VRCON.2;
+  VRCON_VR1         : bit  absolute VRCON.1;
+  VRCON_VR0         : bit  absolute VRCON.0;
+  ADRESL            : byte absolute $009e;
+  ADCON1            : byte absolute $009f;
+  ADCON1_ADCS2      : bit  absolute ADCON1.6;
+  ADCON1_ADCS1      : bit  absolute ADCON1.5;
+  ADCON1_ADCS0      : bit  absolute ADCON1.4;
+  WDTCON            : byte absolute $0105;
+  WDTCON_WDTPS3     : bit  absolute WDTCON.4;
+  WDTCON_WDTPS2     : bit  absolute WDTCON.3;
+  WDTCON_WDTPS1     : bit  absolute WDTCON.2;
+  WDTCON_WDTPS0     : bit  absolute WDTCON.1;
+  WDTCON_SWDTEN     : bit  absolute WDTCON.0;
+  LCDCON            : byte absolute $0107;
+  LCDCON_LCDEN      : bit  absolute LCDCON.7;
+  LCDCON_SLPEN      : bit  absolute LCDCON.6;
+  LCDCON_WERR       : bit  absolute LCDCON.5;
+  LCDCON_VLCDEN     : bit  absolute LCDCON.4;
+  LCDCON_CS1        : bit  absolute LCDCON.3;
+  LCDCON_CS0        : bit  absolute LCDCON.2;
+  LCDCON_LMUX1      : bit  absolute LCDCON.1;
+  LCDCON_LMUX0      : bit  absolute LCDCON.0;
+  LCDPS             : byte absolute $0108;
+  LCDPS_WFT         : bit  absolute LCDPS.7;
+  LCDPS_BIASMD      : bit  absolute LCDPS.6;
+  LCDPS_LCDA        : bit  absolute LCDPS.5;
+  LCDPS_WA          : bit  absolute LCDPS.4;
+  LCDPS_LP3         : bit  absolute LCDPS.3;
+  LCDPS_LP2         : bit  absolute LCDPS.2;
+  LCDPS_LP1         : bit  absolute LCDPS.1;
+  LCDPS_LP0         : bit  absolute LCDPS.0;
+  LVDCON            : byte absolute $0109;
+  LVDCON_IRVST      : bit  absolute LVDCON.5;
+  LVDCON_LVDEN      : bit  absolute LVDCON.4;
+  LVDCON_LVDL2      : bit  absolute LVDCON.2;
+  LVDCON_LVDL1      : bit  absolute LVDCON.1;
+  LVDCON_LVDL0      : bit  absolute LVDCON.0;
+  EEDATL            : byte absolute $010c;
+  EEDATL_EEDATL7    : bit  absolute EEDATL.7;
+  EEDATL_EEDATL6    : bit  absolute EEDATL.6;
+  EEDATL_EEDATL5    : bit  absolute EEDATL.5;
+  EEDATL_EEDATL4    : bit  absolute EEDATL.4;
+  EEDATL_EEDATL3    : bit  absolute EEDATL.3;
+  EEDATL_EEDATL2    : bit  absolute EEDATL.2;
+  EEDATL_EEDATL1    : bit  absolute EEDATL.1;
+  EEDATL_EEDATL0    : bit  absolute EEDATL.0;
+  EEADRL            : byte absolute $010d;
+  EEADRL_EEADRL7    : bit  absolute EEADRL.7;
+  EEADRL_EEADRL6    : bit  absolute EEADRL.6;
+  EEADRL_EEADRL5    : bit  absolute EEADRL.5;
+  EEADRL_EEADRL4    : bit  absolute EEADRL.4;
+  EEADRL_EEADRL3    : bit  absolute EEADRL.3;
+  EEADRL_EEADRL2    : bit  absolute EEADRL.2;
+  EEADRL_EEADRL1    : bit  absolute EEADRL.1;
+  EEADRL_EEADRL0    : bit  absolute EEADRL.0;
+  EEDATH            : byte absolute $010e;
+  EEDATH_EEDATH5    : bit  absolute EEDATH.5;
+  EEDATH_EEDATH4    : bit  absolute EEDATH.4;
+  EEDATH_EEDATH3    : bit  absolute EEDATH.3;
+  EEDATH_EEDATH2    : bit  absolute EEDATH.2;
+  EEDATH_EEDATH1    : bit  absolute EEDATH.1;
+  EEDATH_EEDATH0    : bit  absolute EEDATH.0;
+  EEADRH            : byte absolute $010f;
+  EEADRH_EEADRH4    : bit  absolute EEADRH.4;
+  EEADRH_EEADRH3    : bit  absolute EEADRH.3;
+  EEADRH_EEADRH2    : bit  absolute EEADRH.2;
+  EEADRH_EEADRH1    : bit  absolute EEADRH.1;
+  EEADRH_EEADRH0    : bit  absolute EEADRH.0;
+  LCDDATA0          : byte absolute $0110;
+  LCDDATA0_SEG7     : bit  absolute LCDDATA0.7;
+  LCDDATA0_SEG6     : bit  absolute LCDDATA0.6;
+  LCDDATA0_SEG5     : bit  absolute LCDDATA0.5;
+  LCDDATA0_SEG4     : bit  absolute LCDDATA0.4;
+  LCDDATA0_SEG3     : bit  absolute LCDDATA0.3;
+  LCDDATA0_SEG2     : bit  absolute LCDDATA0.2;
+  LCDDATA0_SEG1     : bit  absolute LCDDATA0.1;
+  LCDDATA0_SEG0     : bit  absolute LCDDATA0.0;
+  LCDDATA1          : byte absolute $0111;
+  LCDDATA1_SEG15    : bit  absolute LCDDATA1.7;
+  LCDDATA1_SEG14    : bit  absolute LCDDATA1.6;
+  LCDDATA1_SEG13    : bit  absolute LCDDATA1.5;
+  LCDDATA1_SEG12    : bit  absolute LCDDATA1.4;
+  LCDDATA1_SEG11    : bit  absolute LCDDATA1.3;
+  LCDDATA1_SEG10    : bit  absolute LCDDATA1.2;
+  LCDDATA1_SEG9     : bit  absolute LCDDATA1.1;
+  LCDDATA1_SEG8     : bit  absolute LCDDATA1.0;
+  LCDDATA2          : byte absolute $0112;
+  LCDDATA2_SEG23    : bit  absolute LCDDATA2.7;
+  LCDDATA2_SEG22    : bit  absolute LCDDATA2.6;
+  LCDDATA2_SEG21    : bit  absolute LCDDATA2.5;
+  LCDDATA2_SEG20    : bit  absolute LCDDATA2.4;
+  LCDDATA2_SEG19    : bit  absolute LCDDATA2.3;
+  LCDDATA2_SEG18    : bit  absolute LCDDATA2.2;
+  LCDDATA2_SEG17    : bit  absolute LCDDATA2.1;
+  LCDDATA2_SEG16    : bit  absolute LCDDATA2.0;
+  LCDDATA3          : byte absolute $0113;
+  LCDDATA4          : byte absolute $0114;
+  LCDDATA5          : byte absolute $0115;
+  LCDDATA6          : byte absolute $0116;
+  LCDDATA7          : byte absolute $0117;
+  LCDDATA8          : byte absolute $0118;
+  LCDDATA9          : byte absolute $0119;
+  LCDDATA10         : byte absolute $011a;
+  LCDDATA11         : byte absolute $011b;
+  LCDSE0            : byte absolute $011c;
+  LCDSE1            : byte absolute $011d;
+  LCDSE2            : byte absolute $011e;
+  TRISF             : byte absolute $0185;
+  TRISF_TRISF7      : bit  absolute TRISF.7;
+  TRISF_TRISF6      : bit  absolute TRISF.6;
+  TRISF_TRISF5      : bit  absolute TRISF.5;
+  TRISF_TRISF4      : bit  absolute TRISF.4;
+  TRISF_TRISF3      : bit  absolute TRISF.3;
+  TRISF_TRISF2      : bit  absolute TRISF.2;
+  TRISF_TRISF1      : bit  absolute TRISF.1;
+  TRISF_TRISF0      : bit  absolute TRISF.0;
+  TRISG             : byte absolute $0187;
+  TRISG_TRISG5      : bit  absolute TRISG.5;
+  TRISG_TRISG4      : bit  absolute TRISG.4;
+  TRISG_TRISG3      : bit  absolute TRISG.3;
+  TRISG_TRISG2      : bit  absolute TRISG.2;
+  TRISG_TRISG1      : bit  absolute TRISG.1;
+  TRISG_TRISG0      : bit  absolute TRISG.0;
+  PORTF             : byte absolute $0188;
+  PORTF_RF7         : bit  absolute PORTF.7;
+  PORTF_RF6         : bit  absolute PORTF.6;
+  PORTF_RF5         : bit  absolute PORTF.5;
+  PORTF_RF4         : bit  absolute PORTF.4;
+  PORTF_RF3         : bit  absolute PORTF.3;
+  PORTF_RF2         : bit  absolute PORTF.2;
+  PORTF_RF1         : bit  absolute PORTF.1;
+  PORTF_RF0         : bit  absolute PORTF.0;
+  PORTG             : byte absolute $0189;
+  PORTG_RG5         : bit  absolute PORTG.5;
+  PORTG_RG4         : bit  absolute PORTG.4;
+  PORTG_RG3         : bit  absolute PORTG.3;
+  PORTG_RG2         : bit  absolute PORTG.2;
+  PORTG_RG1         : bit  absolute PORTG.1;
+  PORTG_RG0         : bit  absolute PORTG.0;
+  EECON1            : byte absolute $018c;
+  EECON1_EEPGD      : bit  absolute EECON1.7;
+  EECON1_WRERR      : bit  absolute EECON1.6;
+  EECON1_WREN       : bit  absolute EECON1.5;
+  EECON1_WR         : bit  absolute EECON1.4;
+  EECON1_RD         : bit  absolute EECON1.3;
+  EECON2            : byte absolute $018d;
+  LCDDATA12         : byte absolute $0190;
+  LCDDATA12_SEG31   : bit  absolute LCDDATA12.7;
+  LCDDATA12_SEG30   : bit  absolute LCDDATA12.6;
+  LCDDATA12_SEG29   : bit  absolute LCDDATA12.5;
+  LCDDATA12_SEG28   : bit  absolute LCDDATA12.4;
+  LCDDATA12_SEG27   : bit  absolute LCDDATA12.3;
+  LCDDATA12_SEG26   : bit  absolute LCDDATA12.2;
+  LCDDATA12_SEG25   : bit  absolute LCDDATA12.1;
+  LCDDATA12_SEG24   : bit  absolute LCDDATA12.0;
+  LCDDATA13         : byte absolute $0191;
+  LCDDATA13_SEG39   : bit  absolute LCDDATA13.7;
+  LCDDATA13_SEG38   : bit  absolute LCDDATA13.6;
+  LCDDATA13_SEG37   : bit  absolute LCDDATA13.5;
+  LCDDATA13_SEG36   : bit  absolute LCDDATA13.4;
+  LCDDATA13_SEG35   : bit  absolute LCDDATA13.3;
+  LCDDATA13_SEG34   : bit  absolute LCDDATA13.2;
+  LCDDATA13_SEG33   : bit  absolute LCDDATA13.1;
+  LCDDATA13_SEG32   : bit  absolute LCDDATA13.0;
+  LCDDATA14         : byte absolute $0192;
+  LCDDATA14_SEG41   : bit  absolute LCDDATA14.1;
+  LCDDATA14_SEG40   : bit  absolute LCDDATA14.0;
+  LCDDATA15         : byte absolute $0193;
+  LCDDATA16         : byte absolute $0194;
+  LCDDATA17         : byte absolute $0195;
+  LCDDATA18         : byte absolute $0196;
+  LCDDATA19         : byte absolute $0197;
+  LCDDATA20         : byte absolute $0198;
+  LCDDATA21         : byte absolute $0199;
+  LCDDATA22         : byte absolute $019a;
+  LCDDATA23         : byte absolute $019b;
+  LCDSE3            : byte absolute $019c;
+  LCDSE4            : byte absolute $019d;
+  LCDSE5            : byte absolute $019e;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-01F:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE, PCLATH, INTCON, PIR1, PIR2, TMR1L, TMR1H, T1CON, TMR2, T2CON, SSPBUF, SSPCON, CCPR1L, CCPR1H, CCP1CON, RCSTA, TXREG, RCREG, CCPR2L, CCPR2H, CCP2CON, ADRESH, ADCON0
+  {$SET_STATE_RAM '020-07F:GPR'} 
+  {$SET_STATE_RAM '080-099:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISA, TRISB, TRISC, TRISD, TRISE, PCLATH, INTCON, PIE1, PIE2, PCON, OSCCON, OSCTUNE, ANSEL, PR2, SSPADD, SSPSTAT, WPUB, IOCB, CMCON1, TXSTA, SPBRG
+  {$SET_STATE_RAM '09C-09F:SFR'}  // CMCON0, VRCON, ADRESL, ADCON1
+  {$SET_STATE_RAM '0A0-0FF:GPR'} 
+  {$SET_STATE_RAM '100-11E:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, WDTCON, PORTB, LCDCON, LCDPS, LVDCON, PCLATH, INTCON, EEDATL, EEADRL, EEDATH, EEADRH, LCDDATA0, LCDDATA1, LCDDATA2, LCDDATA3, LCDDATA4, LCDDATA5, LCDDATA6, LCDDATA7, LCDDATA8, LCDDATA9, LCDDATA10, LCDDATA11, LCDSE0, LCDSE1, LCDSE2
+  {$SET_STATE_RAM '120-17F:GPR'} 
+  {$SET_STATE_RAM '180-18D:SFR'}  // INDF, OPTION_REG, PCL, STATUS, FSR, TRISF, TRISB, TRISG, PORTF, PORTG, PCLATH, INTCON, EECON1, EECON2
+  {$SET_STATE_RAM '190-19E:SFR'}  // LCDDATA12, LCDDATA13, LCDDATA14, LCDDATA15, LCDDATA16, LCDDATA17, LCDDATA18, LCDDATA19, LCDDATA20, LCDDATA21, LCDDATA22, LCDDATA23, LCDSE3, LCDSE4, LCDSE5
+  {$SET_STATE_RAM '1A0-1FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '080-080:bnk0'} // INDF
+  {$SET_MAPPED_RAM '082-084:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '08A-08B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '100-104:bnk0'} // INDF, TMR0, PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '106-106:bnk0'} // PORTB
+  {$SET_MAPPED_RAM '10A-10B:bnk0'} // PCLATH, INTCON
+  {$SET_MAPPED_RAM '180-180:bnk0'} // INDF
+  {$SET_MAPPED_RAM '181-181:bnk1'} // OPTION_REG
+  {$SET_MAPPED_RAM '182-184:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '186-186:bnk1'} // TRISB
+  {$SET_MAPPED_RAM '18A-18B:bnk0'} // PCLATH, INTCON
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '00A:1F'} // PCLATH
+  {$SET_UNIMP_BITS '00D:F5'} // PIR2
+  {$SET_UNIMP_BITS '012:7F'} // T2CON
+  {$SET_UNIMP_BITS '017:3F'} // CCP1CON
+  {$SET_UNIMP_BITS '01D:3F'} // CCP2CON
+  {$SET_UNIMP_BITS '08D:F5'} // PIE2
+  {$SET_UNIMP_BITS '08E:13'} // PCON
+  {$SET_UNIMP_BITS '08F:7F'} // OSCCON
+  {$SET_UNIMP_BITS '090:1F'} // OSCTUNE
+  {$SET_UNIMP_BITS '096:F0'} // IOCB
+  {$SET_UNIMP_BITS '097:03'} // CMCON1
+  {$SET_UNIMP_BITS '098:F7'} // TXSTA
+  {$SET_UNIMP_BITS '09D:AF'} // VRCON
+  {$SET_UNIMP_BITS '09F:70'} // ADCON1
+  {$SET_UNIMP_BITS '105:1F'} // WDTCON
+  {$SET_UNIMP_BITS '109:37'} // LVDCON
+  {$SET_UNIMP_BITS '10E:3F'} // EEDATH
+  {$SET_UNIMP_BITS '10F:1F'} // EEADRH
+  {$SET_UNIMP_BITS '187:3F'} // TRISG
+  {$SET_UNIMP_BITS '189:3F'} // PORTG
+  {$SET_UNIMP_BITS '18C:8F'} // EECON1
+  {$SET_UNIMP_BITS '192:03'} // LCDDATA14
+  {$SET_UNIMP_BITS '195:03'} // LCDDATA17
+  {$SET_UNIMP_BITS '198:03'} // LCDDATA20
+  {$SET_UNIMP_BITS '19B:03'} // LCDDATA23
+  {$SET_UNIMP_BITS '19E:03'} // LCDSE5
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RD6/SEG19
+  // Pin  2 : RD7/SEG20
+  // Pin  3 : RG0/SEG36
+  // Pin  4 : RG1/SEG37
+  // Pin  5 : RG2/SEG38
+  // Pin  6 : RG3/SEG39
+  // Pin  7 : RG4/SEG40
+  // Pin  8 : RG5/SEG41
+  // Pin  9 : Vss
+  // Pin 10 : Vdd
+  // Pin 11 : RF0/SEG32
+  // Pin 12 : RF1/SEG33
+  // Pin 13 : RF2/SEG34
+  // Pin 14 : RF3/SEG35
+  // Pin 15 : RB0/INT/SEG0
+  // Pin 16 : RB1/SEG1
+  // Pin 17 : RB2/SEG2
+  // Pin 18 : RB3/SEG3
+  // Pin 19 : Vdd
+  // Pin 20 : Vss
+  // Pin 21 : RB4/COM0
+  // Pin 22 : RB5/COM1
+  // Pin 23 : RB6/ICSPCLK/ICDCK/SEG14
+  // Pin 24 : RB7/ICSPDAT/ICDDAT/SEG13
+  // Pin 25 : AVss
+  // Pin 26 : AVdd
+  // Pin 27 : RA0/AN0/C1-/SEG12
+  // Pin 28 : RA1/AN1/C2-/SEG7
+  // Pin 29 : RA2/AN2/C2+/Vref-/COM2
+  // Pin 30 : RA3/AN3/C1+/Vref+/SEG15
+  // Pin 31 : RA4/C1OUT/T0CKI/SEG4
+  // Pin 32 : RA5/AN4/C2OUT/SS/SEG5
+  // Pin 33 : RE0/AN5/SEG21
+  // Pin 34 : RE1/AN6/SEG22
+  // Pin 35 : RE2/AN7/SEG23
+  // Pin 36 : RE3/MCLR/Vpp
+  // Pin 37 : RE4/SEG24
+  // Pin 38 : Vdd
+  // Pin 39 : RA7/OSC1/CLKIN/T1OSI
+  // Pin 40 : RA6/OSC2/CLKOUT/T1OSO
+  // Pin 41 : Vss
+  // Pin 42 : RE5/SEG25
+  // Pin 43 : RE6/SEG26
+  // Pin 44 : RE7/SEG27
+  // Pin 45 : RF4/SEG28
+  // Pin 46 : RF5/SEG29
+  // Pin 47 : RF6/SEG20
+  // Pin 48 : RF7/SEG31
+  // Pin 49 : RC0/VLCD1
+  // Pin 50 : RC1/VLCD2
+  // Pin 51 : RC2/VLCD3
+  // Pin 52 : RC3/SEG6
+  // Pin 53 : RD0/COM3
+  // Pin 54 : RD1
+  // Pin 55 : RD2/CCP2
+  // Pin 56 : Vss
+  // Pin 57 : Vdd
+  // Pin 58 : RD3/SEG16
+  // Pin 59 : RC4/T1G/SDO/SEG11
+  // Pin 60 : RC5/T1CKI/CCP1/SEG10
+  // Pin 61 : RC6/TX/CK/SCK/SCL/SEG9
+  // Pin 62 : RC7/RX/DT/SDI/SDA/SEG8
+  // Pin 63 : RD4/SEG17
+  // Pin 64 : RD5/SEG18
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-27,1-28,2-29,3-30,4-31,5-32,6-40,7-39'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-15,1-16,2-17,3-18,4-21,5-22,6-23,7-24'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-49,1-50,2-51,3-52,4-59,5-60,6-61,7-62'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-53,1-54,2-55,3-58,4-63,5-64,6-1,7-2'} // PORTD
+  {$MAP_RAM_TO_PIN '009:0-33,1-34,2-35,3-36,4-37,5-42,6-43,7-44'} // PORTE
+  {$MAP_RAM_TO_PIN '188:0-11,1-12,2-13,3-14,4-45,5-46,6-47,7-48'} // PORTF
+  {$MAP_RAM_TO_PIN '189:0-3,1-4,2-5,3-6,4-7,5-8'} // PORTG
+
+
+  // -- Bits Configuration --
+
+  // DEBUG : In-Circuit Debugger Mode bit
+  {$define _DEBUG_OFF      = $1FFF}  // In-Circuit Debugger disabled, RB6/ISCPCLK and RB7/ICSPDAT are general purpose I/O pins
+  {$define _DEBUG_ON       = $1FFE}  // In-Circuit Debugger enabled, RB6/ICSPCLK and RB7/ICSPDAT are dedicated to the debugger
+
+  // FCMEN : Fail-Safe Clock Monitor Enabled bit
+  {$define _FCMEN_ON       = $1FFF}  // Fail-Safe Clock Monitor is enabled
+  {$define _FCMEN_OFF      = $1FFD}  // Fail-Safe Clock Monitor is disabled
+
+  // IESO : Internal External Switchover bit
+  {$define _IESO_ON        = $1FFF}  // Internal/External Switchover mode is enabled
+  {$define _IESO_OFF       = $1FFB}  // Internal/External Switchover mode is disabled
+
+  // BOREN : Brown-out Reset Selection bits
+  {$define _BOREN_ON       = $1FFF}  // BOR enabled
+  {$define _BOREN_NSLEEP   = $1FF7}  // BOR enabled during operation and disabled in Sleep
+  {$define _BOREN_SBODEN   = $1FEF}  // BOR controlled by SBOREN bit of the PCON register
+  {$define _BOREN_OFF      = $1FE7}  // BOR disabled
+
+  // CPD : Data Code Protection bit
+  {$define _CPD_OFF        = $1FFF}  // Data memory code protection is disabled
+  {$define _CPD_ON         = $1FDF}  // Data memory code protection is enabled
+
+  // CP : Code Protection bit
+  {$define _CP_OFF         = $1FFF}  // Program memory code protection is disabled
+  {$define _CP_ON          = $1FBF}  // Program memory code protection is enabled
+
+  // MCLRE : RE3/MCLR pin function select bit
+  {$define _MCLRE_ON       = $1FFF}  // RE3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF      = $1F7F}  // RE3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // PWRTE : Power Up Timer Enable bit
+  {$define _PWRTE_OFF      = $1FFF}  // PWRT disabled
+  {$define _PWRTE_ON       = $1EFF}  // PWRT enabled
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON        = $1FFF}  // WDT enabled
+  {$define _WDTE_OFF       = $1DFF}  // WDT disabled and can be enabled by SWDTEN bit of the WDTCON register
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_EXTRCCLK  = $1FFF}  // RC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EXTRCIO   = $1BFF}  // RCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, RC on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCCLK = $17FF}  // INTOSC oscillator: CLKOUT function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_INTOSCIO  = $13FF}  // INTOSCIO oscillator: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, I/O function on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_EC        = $0FFF}  // EC: I/O function on RA6/OSC2/CLKOUT/T1OSO pin, CLKIN on RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_HS        = $0BFF}  // HS oscillator: High-speed crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_XT        = $07FF}  // XT oscillator: Crystal/resonator on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+  {$define _FOSC_LP        = $03FF}  // LP oscillator: Low-power crystal on RA6/OSC2/CLKOUT/T1OSO and RA7/OSC1/CLKIN/T1OSI
+
+implementation
+end.


### PR DESCRIPTION
This should cover all the PICs from the mid-range that were not already covered. 
Feel free to review the files before merging.

Added models:

PIC10Fxxx:
    PIC10F320 PIC10F322

PIC12Fxxx:
    PIC12F609 PIC12F615 PIC12F617 PIC12F629 PIC12F635 PIC12F675 PIC12F683 
    PIC12F752

PIC16Fxx:
    PIC16F73 PIC16F74 PIC16F76 PIC16F77 PIC16F83 PIC16F84 PIC16F87 PIC16F88

PIC16F6xx:
    PIC16F610 PIC16F616 PIC16F627 PIC16F627A PIC16F628 PIC16F628A PIC16F630 
    PIC16F631 PIC16F636 PIC16F639 PIC16F648A PIC16F676 PIC16F677 PIC16F684 
    PIC16F685 PIC16F687 PIC16F688 PIC16F689 PIC16F690

PIC16F7xx:
    PIC16F707 PIC16F716 PIC16F720 PIC16F721 PIC16F722 PIC16F722A PIC16F723 
    PIC16F723A PIC16F724 PIC16F726 PIC16F727 PIC16F737 PIC16F747 PIC16F753 
    PIC16F767 PIC16F777 PIC16F785

PIC16F8xx:
    PIC16F818 PIC16F819 PIC16F870 PIC16F871 PIC16F872 PIC16F873 PIC16F874 
    PIC16F874A PIC16F876 PIC16F877 PIC16F882 PIC16F883 PIC16F884 PIC16F886 
    PIC16F887

PIC16F9xx:
    PIC16F913 PIC16F914 PIC16F916 PIC16F917 PIC16F946