### PR TITLE
Added Device units for the PIC Baseline models (see comment for list)

### DIFF
--- a/devices/PIC10F200.pas
+++ b/devices/PIC10F200.pas
@@ -1,0 +1,87 @@
+unit PIC10F200;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F200'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 256}
+
+interface
+var
+  INDF         : byte absolute $0000;
+  TMR0         : byte absolute $0001;
+  PCL          : byte absolute $0002;
+  STATUS       : byte absolute $0003;
+  STATUS_GPWUF : bit  absolute STATUS.7;
+  STATUS_TO    : bit  absolute STATUS.6;
+  STATUS_PD    : bit  absolute STATUS.5;
+  STATUS_Z     : bit  absolute STATUS.4;
+  STATUS_DC    : bit  absolute STATUS.3;
+  STATUS_C     : bit  absolute STATUS.2;
+  FSR          : byte absolute $0004;
+  OSCCAL       : byte absolute $0005;
+  OSCCAL_CAL6  : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5  : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4  : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3  : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2  : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1  : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0  : bit  absolute OSCCAL.1;
+  OSCCAL_FOSC4 : bit  absolute OSCCAL.0;
+  GPIO         : byte absolute $0006;
+  GPIO_GP3     : bit  absolute GPIO.3;
+  GPIO_GP2     : bit  absolute GPIO.2;
+  GPIO_GP1     : bit  absolute GPIO.1;
+  GPIO_GP0     : bit  absolute GPIO.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO
+  {$SET_STATE_RAM '010-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:DF'} // STATUS
+  {$SET_UNIMP_BITS '006:0F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : NC
+  // Pin  2 : Vdd
+  // Pin  3 : GP2/T0CKI/FOSC4
+  // Pin  4 : GP1/ICSPCLK
+  // Pin  5 : GP0/ICSPDAT
+  // Pin  6 : NC
+  // Pin  7 : Vss
+  // Pin  8 : GP3/MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : Master Clear Enable
+  {$define _MCLRE_ON  = $001D}  // GP3/MCLR pin function  is MCLR
+  {$define _MCLRE_OFF = $001C}  // GP3/MCLR pin fuction is digital I/O, MCLR internally tied to VDD
+
+  // CP : Code Protect
+  {$define _CP_OFF    = $001E}  // Code protection off
+  {$define _CP_ON     = $001C}  // Code protection on
+
+  // WDTE : Watchdog Timer
+  {$define _WDTE_ON   = $001C}  // WDT enabled
+  {$define _WDTE_OFF  = $0018}  // WDT disabled
+
+  // OSC : Oscillator
+  {$define _OSC_IntRC = $001C}  // This is the only option. It is here for backward compatibility
+
+implementation
+end.

--- a/devices/PIC10F202.pas
+++ b/devices/PIC10F202.pas
@@ -1,0 +1,87 @@
+unit PIC10F202;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F202'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF         : byte absolute $0000;
+  TMR0         : byte absolute $0001;
+  PCL          : byte absolute $0002;
+  STATUS       : byte absolute $0003;
+  STATUS_GPWUF : bit  absolute STATUS.7;
+  STATUS_TO    : bit  absolute STATUS.6;
+  STATUS_PD    : bit  absolute STATUS.5;
+  STATUS_Z     : bit  absolute STATUS.4;
+  STATUS_DC    : bit  absolute STATUS.3;
+  STATUS_C     : bit  absolute STATUS.2;
+  FSR          : byte absolute $0004;
+  OSCCAL       : byte absolute $0005;
+  OSCCAL_CAL6  : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5  : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4  : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3  : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2  : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1  : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0  : bit  absolute OSCCAL.1;
+  OSCCAL_FOSC4 : bit  absolute OSCCAL.0;
+  GPIO         : byte absolute $0006;
+  GPIO_GP3     : bit  absolute GPIO.3;
+  GPIO_GP2     : bit  absolute GPIO.2;
+  GPIO_GP1     : bit  absolute GPIO.1;
+  GPIO_GP0     : bit  absolute GPIO.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO
+  {$SET_STATE_RAM '008-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:DF'} // STATUS
+  {$SET_UNIMP_BITS '006:0F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : NC
+  // Pin  2 : Vdd
+  // Pin  3 : GP2/T0CKI/FOSC4
+  // Pin  4 : GP1/ICSPCLK
+  // Pin  5 : GP0/ICSPDAT
+  // Pin  6 : NC
+  // Pin  7 : Vss
+  // Pin  8 : GP3/MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : Master Clear Enable
+  {$define _MCLRE_ON  = $001D}  // GP3/MCLR pin function  is MCLR
+  {$define _MCLRE_OFF = $001C}  // GP3/MCLR pin fuction is digital I/O, MCLR internally tied to VDD
+
+  // CP : Code Protect
+  {$define _CP_OFF    = $001E}  // Code protection off
+  {$define _CP_ON     = $001C}  // Code protection on
+
+  // WDTE : Watchdog Timer
+  {$define _WDTE_ON   = $001C}  // WDT enabled
+  {$define _WDTE_OFF  = $0018}  // WDT disabled
+
+  // OSC : Oscillator
+  {$define _OSC_IntRC = $001C}  // This is the only option. It is here for backward compatibility
+
+implementation
+end.

--- a/devices/PIC10F204.pas
+++ b/devices/PIC10F204.pas
@@ -1,0 +1,97 @@
+unit PIC10F204;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F204'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 256}
+
+interface
+var
+  INDF           : byte absolute $0000;
+  TMR0           : byte absolute $0001;
+  PCL            : byte absolute $0002;
+  STATUS         : byte absolute $0003;
+  STATUS_GPWUF   : bit  absolute STATUS.7;
+  STATUS_CWUF    : bit  absolute STATUS.6;
+  STATUS_TO      : bit  absolute STATUS.5;
+  STATUS_PD      : bit  absolute STATUS.4;
+  STATUS_Z       : bit  absolute STATUS.3;
+  STATUS_DC      : bit  absolute STATUS.2;
+  STATUS_C       : bit  absolute STATUS.1;
+  FSR            : byte absolute $0004;
+  OSCCAL         : byte absolute $0005;
+  OSCCAL_CAL6    : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5    : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4    : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3    : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2    : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1    : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0    : bit  absolute OSCCAL.1;
+  OSCCAL_FOSC4   : bit  absolute OSCCAL.0;
+  GPIO           : byte absolute $0006;
+  GPIO_GP3       : bit  absolute GPIO.3;
+  GPIO_GP2       : bit  absolute GPIO.2;
+  GPIO_GP1       : bit  absolute GPIO.1;
+  GPIO_GP0       : bit  absolute GPIO.0;
+  CMCON0         : byte absolute $0007;
+  CMCON0_CMPOUT  : bit  absolute CMCON0.7;
+  CMCON0_COUTEN  : bit  absolute CMCON0.6;
+  CMCON0_POL     : bit  absolute CMCON0.5;
+  CMCON0_CMPT0CS : bit  absolute CMCON0.4;
+  CMCON0_CMPON   : bit  absolute CMCON0.3;
+  CMCON0_CNREF   : bit  absolute CMCON0.2;
+  CMCON0_CPREF   : bit  absolute CMCON0.1;
+  CMCON0_CWU     : bit  absolute CMCON0.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO, CMCON0
+  {$SET_STATE_RAM '010-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:DF'} // STATUS
+  {$SET_UNIMP_BITS '006:0F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : NC
+  // Pin  2 : Vdd
+  // Pin  3 : GP2/T0CKI/COUT/FOSC4
+  // Pin  4 : GP1/ICSPCLK/CIN-
+  // Pin  5 : GP0/ICSPDAT/CIN+
+  // Pin  6 : NC
+  // Pin  7 : Vss
+  // Pin  8 : GP3/MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : Master Clear Enable
+  {$define _MCLRE_ON  = $001D}  // GP3/MCLR pin function  is MCLR
+  {$define _MCLRE_OFF = $001C}  // GP3/MCLR pin fuction is digital I/O, MCLR internally tied to VDD
+
+  // CP : Code Protect
+  {$define _CP_OFF    = $001E}  // Code protection off
+  {$define _CP_ON     = $001C}  // Code protection on
+
+  // WDTE : Watchdog Timer
+  {$define _WDTE_ON   = $001C}  // WDT enabled
+  {$define _WDTE_OFF  = $0018}  // WDT disabled
+
+  // OSC : Oscillator
+  {$define _OSC_IntRC = $001C}  // This is the only option. It is here for backward compatibility
+
+implementation
+end.

--- a/devices/PIC10F206.pas
+++ b/devices/PIC10F206.pas
@@ -1,0 +1,97 @@
+unit PIC10F206;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F206'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF           : byte absolute $0000;
+  TMR0           : byte absolute $0001;
+  PCL            : byte absolute $0002;
+  STATUS         : byte absolute $0003;
+  STATUS_GPWUF   : bit  absolute STATUS.7;
+  STATUS_CWUF    : bit  absolute STATUS.6;
+  STATUS_TO      : bit  absolute STATUS.5;
+  STATUS_PD      : bit  absolute STATUS.4;
+  STATUS_Z       : bit  absolute STATUS.3;
+  STATUS_DC      : bit  absolute STATUS.2;
+  STATUS_C       : bit  absolute STATUS.1;
+  FSR            : byte absolute $0004;
+  OSCCAL         : byte absolute $0005;
+  OSCCAL_CAL6    : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5    : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4    : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3    : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2    : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1    : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0    : bit  absolute OSCCAL.1;
+  OSCCAL_FOSC4   : bit  absolute OSCCAL.0;
+  GPIO           : byte absolute $0006;
+  GPIO_GP3       : bit  absolute GPIO.3;
+  GPIO_GP2       : bit  absolute GPIO.2;
+  GPIO_GP1       : bit  absolute GPIO.1;
+  GPIO_GP0       : bit  absolute GPIO.0;
+  CMCON0         : byte absolute $0007;
+  CMCON0_CMPOUT  : bit  absolute CMCON0.7;
+  CMCON0_COUTEN  : bit  absolute CMCON0.6;
+  CMCON0_POL     : bit  absolute CMCON0.5;
+  CMCON0_CMPT0CS : bit  absolute CMCON0.4;
+  CMCON0_CMPON   : bit  absolute CMCON0.3;
+  CMCON0_CNREF   : bit  absolute CMCON0.2;
+  CMCON0_CPREF   : bit  absolute CMCON0.1;
+  CMCON0_CWU     : bit  absolute CMCON0.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO, CMCON0
+  {$SET_STATE_RAM '008-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:DF'} // STATUS
+  {$SET_UNIMP_BITS '006:0F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : NC
+  // Pin  2 : Vdd
+  // Pin  3 : GP2/T0CKI/COUT/FOSC4
+  // Pin  4 : GP1/ICSPCLK/CIN-
+  // Pin  5 : GP0/ICSPDAT/CIN+
+  // Pin  6 : NC
+  // Pin  7 : Vss
+  // Pin  8 : GP3/MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : Master Clear Enable
+  {$define _MCLRE_ON  = $001D}  // GP3/MCLR pin function  is MCLR
+  {$define _MCLRE_OFF = $001C}  // GP3/MCLR pin fuction is digital I/O, MCLR internally tied to VDD
+
+  // CP : Code Protect
+  {$define _CP_OFF    = $001E}  // Code protection off
+  {$define _CP_ON     = $001C}  // Code protection on
+
+  // WDTE : Watchdog Timer
+  {$define _WDTE_ON   = $001C}  // WDT enabled
+  {$define _WDTE_OFF  = $0018}  // WDT disabled
+
+  // OSC : Oscillator
+  {$define _OSC_IntRC = $001C}  // This is the only option. It is here for backward compatibility
+
+implementation
+end.

--- a/devices/PIC10F220.pas
+++ b/devices/PIC10F220.pas
@@ -1,0 +1,108 @@
+unit PIC10F220;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F220'}
+{$SET PIC_MAXFREQ  = 8000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 256}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_GPWUF    : bit  absolute STATUS.7;
+  STATUS_TO       : bit  absolute STATUS.6;
+  STATUS_PD       : bit  absolute STATUS.5;
+  STATUS_Z        : bit  absolute STATUS.4;
+  STATUS_DC       : bit  absolute STATUS.3;
+  STATUS_C        : bit  absolute STATUS.2;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  OSCCAL_FOSC4    : bit  absolute OSCCAL.0;
+  GPIO            : byte absolute $0006;
+  GPIO_GP3        : bit  absolute GPIO.3;
+  GPIO_GP2        : bit  absolute GPIO.2;
+  GPIO_GP1        : bit  absolute GPIO.1;
+  GPIO_GP0        : bit  absolute GPIO.0;
+  ADCON0          : byte absolute $0007;
+  ADCON0_ANS1     : bit  absolute ADCON0.5;
+  ADCON0_ANS0     : bit  absolute ADCON0.4;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.3;
+  ADCON0_ADON     : bit  absolute ADCON0.2;
+  ADCON0_GO       : bit  absolute ADCON0.1;
+  ADRES           : byte absolute $0008;
+  ADRES_ADRES7    : bit  absolute ADRES.7;
+  ADRES_ADRES6    : bit  absolute ADRES.6;
+  ADRES_ADRES5    : bit  absolute ADRES.5;
+  ADRES_ADRES4    : bit  absolute ADRES.4;
+  ADRES_ADRES3    : bit  absolute ADRES.3;
+  ADRES_ADRES2    : bit  absolute ADRES.2;
+  ADRES_ADRES1    : bit  absolute ADRES.1;
+  ADRES_ADRES0    : bit  absolute ADRES.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-008:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO, ADCON0, ADRES
+  {$SET_STATE_RAM '010-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:DF'} // STATUS
+  {$SET_UNIMP_BITS '006:0F'} // GPIO
+  {$SET_UNIMP_BITS '007:CF'} // ADCON0
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : NC
+  // Pin  2 : Vdd
+  // Pin  3 : GP2/T0CKI/FOSC4
+  // Pin  4 : GP1/AN1/ICSPCLK
+  // Pin  5 : GP0/AN0/ICSPDAT
+  // Pin  6 : NC
+  // Pin  7 : Vss
+  // Pin  8 : GP3/MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : GP3/MCLR Pin Function Select bit
+  {$define _MCLRE_ON    = $001F}  // GP3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF   = $001E}  // GP3/MCLR pin function is digital I/O, MCLR internally tied to VDD
+
+  // CP : Code protection bit
+  {$define _CP_OFF      = $001F}  // Code protection off
+  {$define _CP_ON       = $001D}  // Code protection on
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON     = $001F}  // WDT enabled
+  {$define _WDTE_OFF    = $001B}  // WDT disabled
+
+  // MCPU : Master Clear Pull-up Enable bit
+  {$define _MCPU_OFF    = $001F}  // Pull-up disabled
+  {$define _MCPU_ON     = $0017}  // Pull-up enabled
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_8MHZ = $001F}  // 8 MHz
+  {$define _IOSCFS_4MHZ = $000F}  // 4 MHz
+
+implementation
+end.

--- a/devices/PIC10F222.pas
+++ b/devices/PIC10F222.pas
@@ -1,0 +1,108 @@
+unit PIC10F222;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC10F222'}
+{$SET PIC_MAXFREQ  = 8000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_GPWUF    : bit  absolute STATUS.7;
+  STATUS_TO       : bit  absolute STATUS.6;
+  STATUS_PD       : bit  absolute STATUS.5;
+  STATUS_Z        : bit  absolute STATUS.4;
+  STATUS_DC       : bit  absolute STATUS.3;
+  STATUS_C        : bit  absolute STATUS.2;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  OSCCAL_FOSC4    : bit  absolute OSCCAL.0;
+  GPIO            : byte absolute $0006;
+  GPIO_GP3        : bit  absolute GPIO.3;
+  GPIO_GP2        : bit  absolute GPIO.2;
+  GPIO_GP1        : bit  absolute GPIO.1;
+  GPIO_GP0        : bit  absolute GPIO.0;
+  ADCON0          : byte absolute $0007;
+  ADCON0_ANS1     : bit  absolute ADCON0.5;
+  ADCON0_ANS0     : bit  absolute ADCON0.4;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.3;
+  ADCON0_ADON     : bit  absolute ADCON0.2;
+  ADCON0_GO       : bit  absolute ADCON0.1;
+  ADRES           : byte absolute $0008;
+  ADRES_ADRES7    : bit  absolute ADRES.7;
+  ADRES_ADRES6    : bit  absolute ADRES.6;
+  ADRES_ADRES5    : bit  absolute ADRES.5;
+  ADRES_ADRES4    : bit  absolute ADRES.4;
+  ADRES_ADRES3    : bit  absolute ADRES.3;
+  ADRES_ADRES2    : bit  absolute ADRES.2;
+  ADRES_ADRES1    : bit  absolute ADRES.1;
+  ADRES_ADRES0    : bit  absolute ADRES.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-008:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO, ADCON0, ADRES
+  {$SET_STATE_RAM '009-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:DF'} // STATUS
+  {$SET_UNIMP_BITS '006:0F'} // GPIO
+  {$SET_UNIMP_BITS '007:CF'} // ADCON0
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : NC
+  // Pin  2 : Vdd
+  // Pin  3 : GP2/T0CKI/FOSC4
+  // Pin  4 : GP1/AN1/ICSPCLK
+  // Pin  5 : GP0/AN0/ICSPDAT
+  // Pin  6 : NC
+  // Pin  7 : Vss
+  // Pin  8 : GP3/MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : GP3/MCLR Pin Function Select bit
+  {$define _MCLRE_ON    = $001F}  // GP3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF   = $001E}  // GP3/MCLR pin function is digital I/O, MCLR internally tied to VDD
+
+  // CP : Code protection bit
+  {$define _CP_OFF      = $001F}  // Code protection off
+  {$define _CP_ON       = $001D}  // Code protection on
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON     = $001F}  // WDT enabled
+  {$define _WDTE_OFF    = $001B}  // WDT disabled
+
+  // MCPU : Master Clear Pull-up Enable bit
+  {$define _MCPU_OFF    = $001F}  // Pull-up disabled
+  {$define _MCPU_ON     = $0017}  // Pull-up enabled
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_8MHZ = $001F}  // 8 MHz
+  {$define _IOSCFS_4MHZ = $000F}  // 4 MHz
+
+implementation
+end.

--- a/devices/PIC12F508.pas
+++ b/devices/PIC12F508.pas
@@ -1,0 +1,92 @@
+unit PIC12F508;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F508'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF         : byte absolute $0000;
+  TMR0         : byte absolute $0001;
+  PCL          : byte absolute $0002;
+  STATUS       : byte absolute $0003;
+  STATUS_GPWUF : bit  absolute STATUS.7;
+  STATUS_TO    : bit  absolute STATUS.6;
+  STATUS_PD    : bit  absolute STATUS.5;
+  STATUS_Z     : bit  absolute STATUS.4;
+  STATUS_DC    : bit  absolute STATUS.3;
+  STATUS_C     : bit  absolute STATUS.2;
+  FSR          : byte absolute $0004;
+  OSCCAL       : byte absolute $0005;
+  OSCCAL_CAL6  : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5  : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4  : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3  : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2  : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1  : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0  : bit  absolute OSCCAL.1;
+  GPIO         : byte absolute $0006;
+  GPIO_GP5     : bit  absolute GPIO.5;
+  GPIO_GP4     : bit  absolute GPIO.4;
+  GPIO_GP3     : bit  absolute GPIO.3;
+  GPIO_GP2     : bit  absolute GPIO.2;
+  GPIO_GP1     : bit  absolute GPIO.1;
+  GPIO_GP0     : bit  absolute GPIO.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO
+  {$SET_STATE_RAM '007-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:9F'} // STATUS
+  {$SET_UNIMP_BITS '005:FE'} // OSCCAL
+  {$SET_UNIMP_BITS '006:3F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/OSC1/CLKIN
+  // Pin  3 : GP4/OSC2
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/T0CKI
+  // Pin  6 : GP1/ICSPCLK
+  // Pin  7 : GP0/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : GP3/MCLR Pin Function Select bit
+  {$define _MCLRE_ON  = $001F}  // GP3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF = $001E}  // GP3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // CP : Code Protection bit
+  {$define _CP_OFF    = $001F}  // Code protection off
+  {$define _CP_ON     = $001D}  // Code protection on
+
+  // WDT : Watchdog Timer Enable bit
+  {$define _WDT_ON    = $001F}  // WDT enabled
+  {$define _WDT_OFF   = $001B}  // WDT disabled
+
+  // OSC : Oscillator Selection bits
+  {$define _OSC_ExtRC = $001F}  // external RC oscillator
+  {$define _OSC_LP    = $0007}  // LP oscillator
+  {$define _OSC_XT    = $000F}  // XT oscillator
+  {$define _OSC_IntRC = $0017}  // internal RC oscillator
+
+implementation
+end.

--- a/devices/PIC12F509.pas
+++ b/devices/PIC12F509.pas
@@ -1,0 +1,94 @@
+unit PIC12F509;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F509'}
+{$SET PIC_MAXFREQ  = 4000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF         : byte absolute $0000;
+  TMR0         : byte absolute $0001;
+  PCL          : byte absolute $0002;
+  STATUS       : byte absolute $0003;
+  STATUS_GPWUF : bit  absolute STATUS.7;
+  STATUS_PA0   : bit  absolute STATUS.6;
+  STATUS_TO    : bit  absolute STATUS.5;
+  STATUS_PD    : bit  absolute STATUS.4;
+  STATUS_Z     : bit  absolute STATUS.3;
+  STATUS_DC    : bit  absolute STATUS.2;
+  STATUS_C     : bit  absolute STATUS.1;
+  FSR          : byte absolute $0004;
+  OSCCAL       : byte absolute $0005;
+  OSCCAL_CAL6  : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5  : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4  : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3  : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2  : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1  : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0  : bit  absolute OSCCAL.1;
+  GPIO         : byte absolute $0006;
+  GPIO_GP5     : bit  absolute GPIO.5;
+  GPIO_GP4     : bit  absolute GPIO.4;
+  GPIO_GP3     : bit  absolute GPIO.3;
+  GPIO_GP2     : bit  absolute GPIO.2;
+  GPIO_GP1     : bit  absolute GPIO.1;
+  GPIO_GP0     : bit  absolute GPIO.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO
+  {$SET_STATE_RAM '007-01F:GPR'} 
+  {$SET_STATE_RAM '027-03F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:BF'} // STATUS
+  {$SET_UNIMP_BITS '005:FE'} // OSCCAL
+  {$SET_UNIMP_BITS '006:3F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/OSC1/CLKIN
+  // Pin  3 : GP4/OSC2
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/T0CKI
+  // Pin  6 : GP1/ICSPCLK
+  // Pin  7 : GP0/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : GP3/MCLR Pin Function Select bit
+  {$define _MCLRE_ON  = $001F}  // GP3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF = $001E}  // GP3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // CP : Code Protection bit
+  {$define _CP_OFF    = $001F}  // Code protection off
+  {$define _CP_ON     = $001D}  // Code protection on
+
+  // WDT : Watchdog Timer Enable bit
+  {$define _WDT_ON    = $001F}  // WDT enabled
+  {$define _WDT_OFF   = $001B}  // WDT disabled
+
+  // OSC : Oscillator Selection bits
+  {$define _OSC_ExtRC = $001F}  // external RC oscillator
+  {$define _OSC_LP    = $0007}  // LP oscillator
+  {$define _OSC_XT    = $000F}  // XT oscillator
+  {$define _OSC_IntRC = $0017}  // internal RC oscillator
+
+implementation
+end.

--- a/devices/PIC12F510.pas
+++ b/devices/PIC12F510.pas
@@ -1,0 +1,117 @@
+unit PIC12F510;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F510'}
+{$SET PIC_MAXFREQ  = 8000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_GPWUF    : bit  absolute STATUS.7;
+  STATUS_CWUF     : bit  absolute STATUS.6;
+  STATUS_PA0      : bit  absolute STATUS.5;
+  STATUS_TO       : bit  absolute STATUS.4;
+  STATUS_PD       : bit  absolute STATUS.3;
+  STATUS_Z        : bit  absolute STATUS.2;
+  STATUS_DC       : bit  absolute STATUS.1;
+  STATUS_C        : bit  absolute STATUS.0;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  GPIO            : byte absolute $0006;
+  GPIO_GP5        : bit  absolute GPIO.5;
+  GPIO_GP4        : bit  absolute GPIO.4;
+  GPIO_GP3        : bit  absolute GPIO.3;
+  GPIO_GP2        : bit  absolute GPIO.2;
+  GPIO_GP1        : bit  absolute GPIO.1;
+  GPIO_GP0        : bit  absolute GPIO.0;
+  CM1CON0         : byte absolute $0007;
+  CM1CON0_C1OUT   : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUTEN : bit  absolute CM1CON0.6;
+  CM1CON0_C1POL   : bit  absolute CM1CON0.5;
+  CM1CON0_C1T0CS  : bit  absolute CM1CON0.4;
+  CM1CON0_C1ON    : bit  absolute CM1CON0.3;
+  CM1CON0_C1NREF  : bit  absolute CM1CON0.2;
+  CM1CON0_C1PREF  : bit  absolute CM1CON0.1;
+  CM1CON0_C1WU    : bit  absolute CM1CON0.0;
+  ADCON0          : byte absolute $0008;
+  ADCON0_ANS1     : bit  absolute ADCON0.7;
+  ADCON0_ANS0     : bit  absolute ADCON0.6;
+  ADCON0_ADCS1    : bit  absolute ADCON0.5;
+  ADCON0_ADCS0    : bit  absolute ADCON0.4;
+  ADCON0_CHS1     : bit  absolute ADCON0.3;
+  ADCON0_CHS0     : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.1;
+  ADCON0_ADON     : bit  absolute ADCON0.0;
+  ADRES           : byte absolute $0009;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-009:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO, CM1CON0, ADCON0, ADRES
+  {$SET_STATE_RAM '00A-01F:GPR'} 
+  {$SET_STATE_RAM '02A-03F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:FE'} // OSCCAL
+  {$SET_UNIMP_BITS '006:3F'} // GPIO
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/OSC1/CLKIN
+  // Pin  3 : GP4/OSC2
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/AN2/T0CKI/C1OUT
+  // Pin  6 : GP1/AN1/C1IN-/ICSPCLK
+  // Pin  7 : GP0/AN0/C1IN+/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_ON  = $003F}  // 8 MHz INTOSC Speed
+  {$define _IOSCFS_OFF = $003E}  // 4 MHz INTOSC Speed
+
+  // MCLRE : Master Clear Enable bit
+  {$define _MCLRE_ON   = $003F}  // GP3/MCLR Functions as MCLR
+  {$define _MCLRE_OFF  = $003D}  // GP3/MCLR pin functions as GP3, MCLR internally tied to VDD
+
+  // CP : Code Protect
+  {$define _CP_OFF     = $003F}  // Code protection off
+  {$define _CP_ON      = $003B}  // Code protection on
+
+  // WDT : Watchdog Timer Enable bit
+  {$define _WDT_ON     = $003F}  // WDT enabled
+  {$define _WDT_OFF    = $0037}  // WDT disabled
+
+  // OSC : Oscillator Select
+  {$define _OSC_ExtRC  = $003F}  // EXTRC with 1.125 ms DRT
+  {$define _OSC_IntRC  = $002F}  // INTOSC with 1.125 ms DRT
+  {$define _OSC_XT     = $001F}  // XT oscillator with 18 ms DRT
+  {$define _OSC_LP     = $000F}  // LP oscillator with 18 ms DRT
+
+implementation
+end.

--- a/devices/PIC12F519.pas
+++ b/devices/PIC12F519.pas
@@ -1,0 +1,119 @@
+unit PIC12F519;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC12F519'}
+{$SET PIC_MAXFREQ  = 8000000}
+{$SET PIC_NPINS    = 8}
+{$SET PIC_NUMBANKS = 2}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF         : byte absolute $0000;
+  TMR0         : byte absolute $0001;
+  PCL          : byte absolute $0002;
+  STATUS       : byte absolute $0003;
+  STATUS_GPWUF : bit  absolute STATUS.7;
+  STATUS_PA0   : bit  absolute STATUS.6;
+  STATUS_TO    : bit  absolute STATUS.5;
+  STATUS_PD    : bit  absolute STATUS.4;
+  STATUS_Z     : bit  absolute STATUS.3;
+  STATUS_DC    : bit  absolute STATUS.2;
+  STATUS_C     : bit  absolute STATUS.1;
+  FSR          : byte absolute $0004;
+  OSCCAL       : byte absolute $0005;
+  OSCCAL_CAL6  : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5  : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4  : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3  : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2  : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1  : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0  : bit  absolute OSCCAL.1;
+  GPIO         : byte absolute $0006;
+  GPIO_GP5     : bit  absolute GPIO.5;
+  GPIO_GP4     : bit  absolute GPIO.4;
+  GPIO_GP3     : bit  absolute GPIO.3;
+  GPIO_GP2     : bit  absolute GPIO.2;
+  GPIO_GP1     : bit  absolute GPIO.1;
+  GPIO_GP0     : bit  absolute GPIO.0;
+  EECON        : byte absolute $0021;
+  EECON_FREE   : bit  absolute EECON.4;
+  EECON_WRERR  : bit  absolute EECON.3;
+  EECON_WREN   : bit  absolute EECON.2;
+  EECON_WR     : bit  absolute EECON.1;
+  EECON_RD     : bit  absolute EECON.0;
+  EEDATA       : byte absolute $0025;
+  EEADR        : byte absolute $0026;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, GPIO
+  {$SET_STATE_RAM '007-01F:GPR'} 
+  {$SET_STATE_RAM '020-026:SFR'}  // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR
+  {$SET_STATE_RAM '027-03F:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '020-020:bnk0'} // INDF
+  {$SET_MAPPED_RAM '022-024:bnk0'} // PCL, STATUS, FSR
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '003:BF'} // STATUS
+  {$SET_UNIMP_BITS '005:FE'} // OSCCAL
+  {$SET_UNIMP_BITS '006:3F'} // GPIO
+  {$SET_UNIMP_BITS '021:1F'} // EECON
+  {$SET_UNIMP_BITS '026:3F'} // EEADR
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : GP5/OSC1/CLKIN
+  // Pin  3 : GP4/OSC2
+  // Pin  4 : GP3/MCLR/Vpp
+  // Pin  5 : GP2/T0CKI
+  // Pin  6 : GP1/ICSPCLK
+  // Pin  7 : GP0/ICSPDAT
+  // Pin  8 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+
+
+  // -- Bits Configuration --
+
+  // CPDF : Code Protection bit - Flash Data Memory
+  {$define _CPDF_OFF    = $007F}  // Code protection off
+  {$define _CPDF_ON     = $007E}  // Code protection on
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_8MHz = $007F}  // 8 MHz INTOSC Speed
+  {$define _IOSCFS_4MHz = $007D}  // 4 MHz INTOSC Speed
+
+  // MCLRE : Master Clear Enable bit
+  {$define _MCLRE_ON    = $007F}  // RB3/MCLR Functions as MCLR
+  {$define _MCLRE_OFF   = $007B}  // RB3/MCLR Functions as RB3
+
+  // CP : Code Protection bit
+  {$define _CP_OFF      = $007F}  // Code protection off
+  {$define _CP_ON       = $0077}  // Code protection on
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON     = $007F}  // Enabled
+  {$define _WDTE_OFF    = $006F}  // Disabled
+
+  // FOSC : Oscillator Selection bits
+  {$define _FOSC_LP     = $001F}  // LP Osc With 18 ms DRT
+  {$define _FOSC_XT     = $003F}  // XT Osc With 18 ms DRT
+  {$define _FOSC_INTRC  = $005F}  // INTRC With 1 ms DRT
+  {$define _FOSC_EXTRC  = $007F}  // EXTRC With 1 ms DRT
+
+implementation
+end.

--- a/devices/PIC16F505.pas
+++ b/devices/PIC16F505.pas
@@ -1,0 +1,115 @@
+unit PIC16F505;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F505'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF         : byte absolute $0000;
+  TMR0         : byte absolute $0001;
+  PCL          : byte absolute $0002;
+  STATUS       : byte absolute $0003;
+  STATUS_RBWUF : bit  absolute STATUS.7;
+  STATUS_PA0   : bit  absolute STATUS.6;
+  STATUS_TO    : bit  absolute STATUS.5;
+  STATUS_PD    : bit  absolute STATUS.4;
+  STATUS_Z     : bit  absolute STATUS.3;
+  STATUS_DC    : bit  absolute STATUS.2;
+  STATUS_C     : bit  absolute STATUS.1;
+  FSR          : byte absolute $0004;
+  OSCCAL       : byte absolute $0005;
+  OSCCAL_CAL6  : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5  : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4  : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3  : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2  : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1  : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0  : bit  absolute OSCCAL.1;
+  PORTB        : byte absolute $0006;
+  PORTB_RB5    : bit  absolute PORTB.5;
+  PORTB_RB4    : bit  absolute PORTB.4;
+  PORTB_RB3    : bit  absolute PORTB.3;
+  PORTB_RB2    : bit  absolute PORTB.2;
+  PORTB_RB1    : bit  absolute PORTB.1;
+  PORTB_RB0    : bit  absolute PORTB.0;
+  PORTC        : byte absolute $0007;
+  PORTC_RC5    : bit  absolute PORTC.5;
+  PORTC_RC4    : bit  absolute PORTC.4;
+  PORTC_RC3    : bit  absolute PORTC.3;
+  PORTC_RC2    : bit  absolute PORTC.2;
+  PORTC_RC1    : bit  absolute PORTC.1;
+  PORTC_RC0    : bit  absolute PORTC.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTB, PORTC
+  {$SET_STATE_RAM '008-01F:GPR'} 
+  {$SET_STATE_RAM '028-03F:GPR'} 
+  {$SET_STATE_RAM '048-05F:GPR'} 
+  {$SET_STATE_RAM '068-07F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:FE'} // OSCCAL
+  {$SET_UNIMP_BITS '006:3F'} // PORTB
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RB5/OSC1/CLKIN
+  // Pin  3 : RB4/OSC2/CLKOUT
+  // Pin  4 : RB3/MCLR/Vpp
+  // Pin  5 : RC5/T0CKI
+  // Pin  6 : RC4
+  // Pin  7 : RC3
+  // Pin  8 : RC2
+  // Pin  9 : RC1
+  // Pin 10 : RC0
+  // Pin 11 : RB2
+  // Pin 12 : RB1/ICSPCLK
+  // Pin 13 : RB0/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '006:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // MCLRE : RB3/MCLR Pin Function Select bit
+  {$define _MCLRE_ON           = $003F}  // RB3/MCLR pin function is MCLR
+  {$define _MCLRE_OFF          = $003E}  // GP3/MCLR pin function is digital input, MCLR internally tied to VDD
+
+  // CP : Code Protection bit
+  {$define _CP_OFF             = $003F}  // Code protection off
+  {$define _CP_ON              = $003D}  // Code protection on
+
+  // WDT : Watchdog Timer Enable bit
+  {$define _WDT_ON             = $003F}  // WDT enabled
+  {$define _WDT_OFF            = $003B}  // WDT disabled
+
+  // OSC : Oscillator Selection bits
+  {$define _OSC_ExtRC_CLKOUTEN = $003F}  // External RC oscillator/CLKOUT function on RB4/OSC2/CLKOUT pin
+  {$define _OSC_ExtRC_RB4EN    = $0037}  // External RC oscillator/RB4 function on RB4/OSC2/CLKOUT pin
+  {$define _OSC_IntRC_CLKOUTEN = $002F}  // Internal RC oscillator/CLKOUT function on RB4/OSC2/CLKOUT pin
+  {$define _OSC_IntRC_RB4EN    = $0027}  // Internal RC oscillator/RB4 function on RB4/OSC2/CLKOUT pin
+  {$define _OSC_EC             = $001F}  // EC oscillator/RB4 function on RB4/OSC2/CLKOUT pin
+  {$define _OSC_HS             = $0017}  // HS oscillator
+  {$define _OSC_XT             = $000F}  // XT oscillator
+  {$define _OSC_LP             = $0007}  // LP oscillator
+
+implementation
+end.

--- a/devices/PIC16F506.pas
+++ b/devices/PIC16F506.pas
@@ -1,0 +1,157 @@
+unit PIC16F506;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F506'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_RBWUF    : bit  absolute STATUS.7;
+  STATUS_CWUF     : bit  absolute STATUS.6;
+  STATUS_PA0      : bit  absolute STATUS.5;
+  STATUS_TO       : bit  absolute STATUS.4;
+  STATUS_PD       : bit  absolute STATUS.3;
+  STATUS_Z        : bit  absolute STATUS.2;
+  STATUS_DC       : bit  absolute STATUS.1;
+  STATUS_C        : bit  absolute STATUS.0;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  PORTB           : byte absolute $0006;
+  PORTB_RB5       : bit  absolute PORTB.5;
+  PORTB_RB4       : bit  absolute PORTB.4;
+  PORTB_RB3       : bit  absolute PORTB.3;
+  PORTB_RB2       : bit  absolute PORTB.2;
+  PORTB_RB1       : bit  absolute PORTB.1;
+  PORTB_RB0       : bit  absolute PORTB.0;
+  PORTC           : byte absolute $0007;
+  PORTC_RC5       : bit  absolute PORTC.5;
+  PORTC_RC4       : bit  absolute PORTC.4;
+  PORTC_RC3       : bit  absolute PORTC.3;
+  PORTC_RC2       : bit  absolute PORTC.2;
+  PORTC_RC1       : bit  absolute PORTC.1;
+  PORTC_RC0       : bit  absolute PORTC.0;
+  CM1CON0         : byte absolute $0008;
+  CM1CON0_C1OUT   : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUTEN : bit  absolute CM1CON0.6;
+  CM1CON0_C1POL   : bit  absolute CM1CON0.5;
+  CM1CON0_C1T0CS  : bit  absolute CM1CON0.4;
+  CM1CON0_C1ON    : bit  absolute CM1CON0.3;
+  CM1CON0_C1NREF  : bit  absolute CM1CON0.2;
+  CM1CON0_C1PREF  : bit  absolute CM1CON0.1;
+  CM1CON0_C1WU    : bit  absolute CM1CON0.0;
+  ADCON0          : byte absolute $0009;
+  ADCON0_ANS1     : bit  absolute ADCON0.7;
+  ADCON0_ANS0     : bit  absolute ADCON0.6;
+  ADCON0_ADCS1    : bit  absolute ADCON0.5;
+  ADCON0_ADCS0    : bit  absolute ADCON0.4;
+  ADCON0_CHS1     : bit  absolute ADCON0.3;
+  ADCON0_CHS0     : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.1;
+  ADCON0_ADON     : bit  absolute ADCON0.0;
+  ADRES           : byte absolute $000A;
+  CM2CON0         : byte absolute $000B;
+  CM2CON0_C2OUT   : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUTEN : bit  absolute CM2CON0.6;
+  CM2CON0_C2POL   : bit  absolute CM2CON0.5;
+  CM2CON0_C2PREF2 : bit  absolute CM2CON0.4;
+  CM2CON0_C2ON    : bit  absolute CM2CON0.3;
+  CM2CON0_C2NREF  : bit  absolute CM2CON0.2;
+  CM2CON0_C2PREF1 : bit  absolute CM2CON0.1;
+  CM2CON0_C2WU    : bit  absolute CM2CON0.0;
+  VRCON           : byte absolute $000C;
+  VRCON_VREN      : bit  absolute VRCON.7;
+  VRCON_VROE      : bit  absolute VRCON.6;
+  VRCON_VRR       : bit  absolute VRCON.5;
+  VRCON_VR3       : bit  absolute VRCON.3;
+  VRCON_VR2       : bit  absolute VRCON.2;
+  VRCON_VR1       : bit  absolute VRCON.1;
+  VRCON_VR0       : bit  absolute VRCON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-00C:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTB, PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_STATE_RAM '00D-01F:GPR'} 
+  {$SET_STATE_RAM '02D-03F:GPR'} 
+  {$SET_STATE_RAM '04D-05F:GPR'} 
+  {$SET_STATE_RAM '06D-07F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:FE'} // OSCCAL
+  {$SET_UNIMP_BITS '006:3F'} // PORTB
+  {$SET_UNIMP_BITS '007:3F'} // PORTC
+  {$SET_UNIMP_BITS '00C:EF'} // VRCON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RB5/OSC1/CLKIN
+  // Pin  3 : RB4/OSC2/CLKOUT
+  // Pin  4 : RB3/MCLR/Vpp
+  // Pin  5 : RC5/T0CKI
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3
+  // Pin  8 : RC2/CVref
+  // Pin  9 : RC1/C2IN-
+  // Pin 10 : RC0/C2IN+
+  // Pin 11 : RB2/AN2/C1OUT
+  // Pin 12 : RB1/AN1/C1IN-/ICSPCLK
+  // Pin 13 : RB0/AN0/C1IN+/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '006:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // IOSCFS : Internal Oscillator Frequency Select bit
+  {$define _IOSCFS_ON          = $007F}  // 8 MHz INTOSC Speed
+  {$define _IOSCFS_OFF         = $007E}  // 4 MHz INTOSC Speed
+
+  // MCLRE : Master Clear Enable bit
+  {$define _MCLRE_ON           = $007F}  // RB3/MCLR pin functions as MCLR
+  {$define _MCLRE_OFF          = $007D}  // RB3/MCLR pin functions as RB3, MCLR tied internally to VDD
+
+  // CP : Code Protect
+  {$define _CP_OFF             = $007F}  // Code protection off
+  {$define _CP_ON              = $007B}  // Code protection on
+
+  // WDT : Watchdog Timer Enable bit
+  {$define _WDT_ON             = $007F}  // WDT enabled
+  {$define _WDT_OFF            = $0077}  // WDT disabled
+
+  // OSC : Oscillator Selection bits
+  {$define _OSC_LP             = $000F}  // LP oscillator and 18 ms DRT
+  {$define _OSC_XT             = $001F}  // XT oscillator and 18 ms DRT
+  {$define _OSC_HS             = $002F}  // HS oscillator and 18 ms DRT
+  {$define _OSC_EC             = $003F}  // EC Osc With RB4 and 1.125 ms DRT
+  {$define _OSC_IntRC_RB4EN    = $004F}  // INTRC With RB4 and 1.125 ms DRT
+  {$define _OSC_IntRC_CLKOUTEN = $005F}  // INTRC With CLKOUT and 1.125 ms DRT
+  {$define _OSC_ExtRC_RB4EN    = $006F}  // EXTRC With RB4 and 1.125 ms DRT
+  {$define _OSC_ExtRC_CLKOUTEN = $007F}  // EXTRC With CLKOUT and 1.125 ms DRT
+
+implementation
+end.

--- a/devices/PIC16F526.pas
+++ b/devices/PIC16F526.pas
@@ -1,0 +1,188 @@
+unit PIC16F526;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F526'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 14}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_RBWUF    : bit  absolute STATUS.7;
+  STATUS_CWUF     : bit  absolute STATUS.6;
+  STATUS_PA0      : bit  absolute STATUS.5;
+  STATUS_TO       : bit  absolute STATUS.4;
+  STATUS_PD       : bit  absolute STATUS.3;
+  STATUS_Z        : bit  absolute STATUS.2;
+  STATUS_DC       : bit  absolute STATUS.1;
+  STATUS_C        : bit  absolute STATUS.0;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  PORTB           : byte absolute $0006;
+  PORTB_RB5       : bit  absolute PORTB.5;
+  PORTB_RB4       : bit  absolute PORTB.4;
+  PORTB_RB3       : bit  absolute PORTB.3;
+  PORTB_RB2       : bit  absolute PORTB.2;
+  PORTB_RB1       : bit  absolute PORTB.1;
+  PORTB_RB0       : bit  absolute PORTB.0;
+  PORTC           : byte absolute $0007;
+  PORTC_RC5       : bit  absolute PORTC.5;
+  PORTC_RC4       : bit  absolute PORTC.4;
+  PORTC_RC3       : bit  absolute PORTC.3;
+  PORTC_RC2       : bit  absolute PORTC.2;
+  PORTC_RC1       : bit  absolute PORTC.1;
+  PORTC_RC0       : bit  absolute PORTC.0;
+  CM1CON0         : byte absolute $0008;
+  CM1CON0_C1OUT   : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUTEN : bit  absolute CM1CON0.6;
+  CM1CON0_C1POL   : bit  absolute CM1CON0.5;
+  CM1CON0_C1T0CS  : bit  absolute CM1CON0.4;
+  CM1CON0_C1ON    : bit  absolute CM1CON0.3;
+  CM1CON0_C1NREF  : bit  absolute CM1CON0.2;
+  CM1CON0_C1PREF  : bit  absolute CM1CON0.1;
+  CM1CON0_C1WU    : bit  absolute CM1CON0.0;
+  ADCON0          : byte absolute $0009;
+  ADCON0_ANS1     : bit  absolute ADCON0.7;
+  ADCON0_ANS0     : bit  absolute ADCON0.6;
+  ADCON0_ADCS1    : bit  absolute ADCON0.5;
+  ADCON0_ADCS0    : bit  absolute ADCON0.4;
+  ADCON0_CHS1     : bit  absolute ADCON0.3;
+  ADCON0_CHS0     : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.1;
+  ADCON0_ADON     : bit  absolute ADCON0.0;
+  ADRES           : byte absolute $000A;
+  ADRES_ADRES7    : bit  absolute ADRES.7;
+  ADRES_ADRES6    : bit  absolute ADRES.6;
+  ADRES_ADRES5    : bit  absolute ADRES.5;
+  ADRES_ADRES4    : bit  absolute ADRES.4;
+  ADRES_ADRES3    : bit  absolute ADRES.3;
+  ADRES_ADRES2    : bit  absolute ADRES.2;
+  ADRES_ADRES1    : bit  absolute ADRES.1;
+  ADRES_ADRES0    : bit  absolute ADRES.0;
+  CM2CON0         : byte absolute $000B;
+  CM2CON0_C2OUT   : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUTEN : bit  absolute CM2CON0.6;
+  CM2CON0_C2POL   : bit  absolute CM2CON0.5;
+  CM2CON0_C2PREF2 : bit  absolute CM2CON0.4;
+  CM2CON0_C2ON    : bit  absolute CM2CON0.3;
+  CM2CON0_C2NREF  : bit  absolute CM2CON0.2;
+  CM2CON0_C2PREF1 : bit  absolute CM2CON0.1;
+  CM2CON0_C2WU    : bit  absolute CM2CON0.0;
+  VRCON           : byte absolute $000C;
+  VRCON_VREN      : bit  absolute VRCON.7;
+  VRCON_VROE      : bit  absolute VRCON.6;
+  VRCON_VRR       : bit  absolute VRCON.5;
+  VRCON_VR3       : bit  absolute VRCON.3;
+  VRCON_VR2       : bit  absolute VRCON.2;
+  VRCON_VR1       : bit  absolute VRCON.1;
+  VRCON_VR0       : bit  absolute VRCON.0;
+  EECON           : byte absolute $0021;
+  EECON_FREE      : bit  absolute EECON.4;
+  EECON_WRERR     : bit  absolute EECON.3;
+  EECON_WREN      : bit  absolute EECON.2;
+  EECON_WR        : bit  absolute EECON.1;
+  EECON_RD        : bit  absolute EECON.0;
+  EEDATA          : byte absolute $0025;
+  EEADR           : byte absolute $0026;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-00C:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTB, PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_STATE_RAM '00D-01F:GPR'} 
+  {$SET_STATE_RAM '020-02C:SFR'}  // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR, PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_STATE_RAM '02D-03F:GPR'} 
+  {$SET_STATE_RAM '040-04C:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTB, PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_STATE_RAM '04D-05F:GPR'} 
+  {$SET_STATE_RAM '060-06C:SFR'}  // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR, PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_STATE_RAM '06D-07F:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '020-020:bnk0'} // INDF
+  {$SET_MAPPED_RAM '022-024:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '027-02C:bnk0'} // PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_MAPPED_RAM '040-04C:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTB, PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+  {$SET_MAPPED_RAM '060-060:bnk0'} // INDF
+  {$SET_MAPPED_RAM '061-061:bnk1'} // EECON
+  {$SET_MAPPED_RAM '062-064:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '065-066:bnk1'} // EEDATA, EEADR
+  {$SET_MAPPED_RAM '067-06C:bnk0'} // PORTC, CM1CON0, ADCON0, ADRES, CM2CON0, VRCON
+
+
+  // -- Initial values --
+
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : Vdd
+  // Pin  2 : RB5/OSC1/CLKIN
+  // Pin  3 : RB4/OSC2/CLKOUT
+  // Pin  4 : RB3/MCLR/Vpp
+  // Pin  5 : RC5/T0CKI
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3
+  // Pin  8 : RC2/CVref
+  // Pin  9 : RC1/C2IN-
+  // Pin 10 : RC0/C2IN+
+  // Pin 11 : RB2/C1OUT/AN2
+  // Pin 12 : RB1/C1IN-/AN1/ICSPCLK
+  // Pin 13 : RB0/C1IN+/AN0/ICSPDAT
+  // Pin 14 : Vss
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '006:0-13,1-12,2-11,3-4,4-3,5-2'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-10,1-9,2-8,3-7,4-6,5-5'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // CPDF : Code Protection bit - Flash Data Memory
+  {$define _CPDF_OFF          = $00FF}  // Code protection off
+  {$define _CPDF_ON           = $00FE}  // Code protection on
+
+  // IOSCFS : Internal Oscillator Frequency Select
+  {$define _IOSCFS_8MHz       = $00FF}  // 8 MHz INTOSC Speed
+  {$define _IOSCFS_4MHz       = $00FD}  // 4 MHz INTOSC Speed
+
+  // MCLRE : Master Clear Enable bit
+  {$define _MCLRE_ON          = $00FF}  // RB3/MCLR functions as MCLR
+  {$define _MCLRE_OFF         = $00FB}  // RB3/MCLR functions as RB3, MCLR internally tied to Vdd
+
+  // CP : Code Protection bit
+  {$define _CP_OFF            = $00FF}  // Code protection off
+  {$define _CP_ON             = $00F7}  // Code protection on
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON           = $00FF}  // Enabled
+  {$define _WDTE_OFF          = $00EF}  // Disabled
+
+  // FOSC : Oscillator
+  {$define _FOSC_LP           = $001F}  // LP oscillator and 18 ms DRT
+  {$define _FOSC_XT           = $003F}  // XT oscillator and 18 ms DRT
+  {$define _FOSC_HS           = $005F}  // HS oscillator and 18 ms DRT
+  {$define _FOSC_EC           = $007F}  // EC oscillator with RB4 function on RB4/OSC2/CLKOUT and 1 ms DRT
+  {$define _FOSC_INTRC_RB4    = $009F}  // INTRC with RB4 function on RB4/OSC2/CLKOUT and 1 ms DRT
+  {$define _FOSC_INTRC_CLKOUT = $00BF}  // INTRC with CLKOUT function on RB4/OSC2/CLKOUT and 1 ms DRT
+  {$define _FOSC_ExtRC_RB4    = $00DF}  // EXTRC with RB4 function on RB4/OSC2/CLKOUT and 1 ms DRT
+  {$define _FOSC_ExtRC_CLKOUT = $00FF}  // EXTRC with CLKOUT function on RB4/OSC2/CLKOUT and 1 ms DRT
+
+implementation
+end.

--- a/devices/PIC16F527.pas
+++ b/devices/PIC16F527.pas
@@ -1,0 +1,247 @@
+unit PIC16F527;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F527'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 20}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 2}
+{$SET PIC_MAXFLASH = 1024}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_PA1      : bit  absolute STATUS.7;
+  STATUS_PA0      : bit  absolute STATUS.6;
+  STATUS_TO       : bit  absolute STATUS.5;
+  STATUS_PD       : bit  absolute STATUS.4;
+  STATUS_Z        : bit  absolute STATUS.3;
+  STATUS_DC       : bit  absolute STATUS.2;
+  STATUS_C        : bit  absolute STATUS.1;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  PORTA           : byte absolute $0006;
+  PORTA_RA5       : bit  absolute PORTA.5;
+  PORTA_RA4       : bit  absolute PORTA.4;
+  PORTA_RA3       : bit  absolute PORTA.3;
+  PORTA_RA2       : bit  absolute PORTA.2;
+  PORTA_RA1       : bit  absolute PORTA.1;
+  PORTA_RA0       : bit  absolute PORTA.0;
+  PORTB           : byte absolute $0007;
+  PORTB_RB7       : bit  absolute PORTB.4;
+  PORTB_RB6       : bit  absolute PORTB.3;
+  PORTB_RB5       : bit  absolute PORTB.2;
+  PORTB_RB4       : bit  absolute PORTB.1;
+  PORTC           : byte absolute $0008;
+  PORTC_RC7       : bit  absolute PORTC.7;
+  PORTC_RC6       : bit  absolute PORTC.6;
+  PORTC_RC5       : bit  absolute PORTC.5;
+  PORTC_RC4       : bit  absolute PORTC.4;
+  PORTC_RC3       : bit  absolute PORTC.3;
+  PORTC_RC2       : bit  absolute PORTC.2;
+  PORTC_RC1       : bit  absolute PORTC.1;
+  PORTC_RC0       : bit  absolute PORTC.0;
+  ADCON0          : byte absolute $0009;
+  ADCON0_ADCS1    : bit  absolute ADCON0.7;
+  ADCON0_ADCS0    : bit  absolute ADCON0.6;
+  ADCON0_CHS3     : bit  absolute ADCON0.5;
+  ADCON0_CHS2     : bit  absolute ADCON0.4;
+  ADCON0_CHS1     : bit  absolute ADCON0.3;
+  ADCON0_CHS0     : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.1;
+  ADCON0_ADON     : bit  absolute ADCON0.0;
+  ADRES           : byte absolute $000A;
+  ADRES_ADRES7    : bit  absolute ADRES.7;
+  ADRES_ADRES6    : bit  absolute ADRES.6;
+  ADRES_ADRES5    : bit  absolute ADRES.5;
+  ADRES_ADRES4    : bit  absolute ADRES.4;
+  ADRES_ADRES3    : bit  absolute ADRES.3;
+  ADRES_ADRES2    : bit  absolute ADRES.2;
+  ADRES_ADRES1    : bit  absolute ADRES.1;
+  ADRES_ADRES0    : bit  absolute ADRES.0;
+  INTCON0         : byte absolute $000B;
+  INTCON0_ADIF    : bit  absolute INTCON0.7;
+  INTCON0_CWIF    : bit  absolute INTCON0.6;
+  INTCON0_T0IF    : bit  absolute INTCON0.5;
+  INTCON0_RAIF    : bit  absolute INTCON0.4;
+  INTCON0_GIE     : bit  absolute INTCON0.3;
+  EECON           : byte absolute $0021;
+  EECON_FREE      : bit  absolute EECON.4;
+  EECON_WRERR     : bit  absolute EECON.3;
+  EECON_WREN      : bit  absolute EECON.2;
+  EECON_WR        : bit  absolute EECON.1;
+  EECON_RD        : bit  absolute EECON.0;
+  EEDATA          : byte absolute $0025;
+  EEADR           : byte absolute $0026;
+  CM1CON0         : byte absolute $0027;
+  CM1CON0_C1OUT   : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUTEN : bit  absolute CM1CON0.6;
+  CM1CON0_C1POL   : bit  absolute CM1CON0.5;
+  CM1CON0_C1T0CS  : bit  absolute CM1CON0.4;
+  CM1CON0_C1ON    : bit  absolute CM1CON0.3;
+  CM1CON0_C1NREF  : bit  absolute CM1CON0.2;
+  CM1CON0_C1PREF  : bit  absolute CM1CON0.1;
+  CM1CON0_C1WU    : bit  absolute CM1CON0.0;
+  CM2CON0         : byte absolute $0028;
+  CM2CON0_C2OUT   : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUTEN : bit  absolute CM2CON0.6;
+  CM2CON0_C2POL   : bit  absolute CM2CON0.5;
+  CM2CON0_C2PREF2 : bit  absolute CM2CON0.4;
+  CM2CON0_C2ON    : bit  absolute CM2CON0.3;
+  CM2CON0_C2NREF  : bit  absolute CM2CON0.2;
+  CM2CON0_C2PREF1 : bit  absolute CM2CON0.1;
+  CM2CON0_C2WU    : bit  absolute CM2CON0.0;
+  VRCON           : byte absolute $0029;
+  VRCON_VREN      : bit  absolute VRCON.7;
+  VRCON_VROE      : bit  absolute VRCON.6;
+  VRCON_VRR       : bit  absolute VRCON.5;
+  VRCON_VR3       : bit  absolute VRCON.3;
+  VRCON_VR2       : bit  absolute VRCON.2;
+  VRCON_VR1       : bit  absolute VRCON.1;
+  VRCON_VR0       : bit  absolute VRCON.0;
+  ANSEL           : byte absolute $002A;
+  ANSEL_ANS7      : bit  absolute ANSEL.7;
+  ANSEL_ANS6      : bit  absolute ANSEL.6;
+  ANSEL_ANS5      : bit  absolute ANSEL.5;
+  ANSEL_ANS4      : bit  absolute ANSEL.4;
+  ANSEL_ANS3      : bit  absolute ANSEL.3;
+  ANSEL_ANS2      : bit  absolute ANSEL.2;
+  ANSEL_ANS1      : bit  absolute ANSEL.1;
+  ANSEL_ANS0      : bit  absolute ANSEL.0;
+  IW              : byte absolute $0061;
+  INTCON1         : byte absolute $0065;
+  INTCON1_ADIE    : bit  absolute INTCON1.7;
+  INTCON1_CWIE    : bit  absolute INTCON1.6;
+  INTCON1_T0IE    : bit  absolute INTCON1.5;
+  INTCON1_RAIE    : bit  absolute INTCON1.4;
+  INTCON1_WUR     : bit  absolute INTCON1.3;
+  ISTATUS         : byte absolute $0066;
+  IFSR            : byte absolute $0067;
+  IBSR            : byte absolute $0068;
+  OPACON          : byte absolute $0069;
+  OPACON_OPA2ON   : bit  absolute OPACON.1;
+  OPACON_OPA1ON   : bit  absolute OPACON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-00B:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_STATE_RAM '00C-01F:GPR'} 
+  {$SET_STATE_RAM '020-02B:SFR'}  // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR, CM1CON0, CM2CON0, VRCON, ANSEL, INTCON0
+  {$SET_STATE_RAM '02C-03F:GPR'} 
+  {$SET_STATE_RAM '040-04B:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_STATE_RAM '04C-05F:GPR'} 
+  {$SET_STATE_RAM '060-06B:SFR'}  // INDF, IW, PCL, STATUS, FSR, INTCON1, ISTATUS, IFSR, IBSR, OPACON, ANSEL, INTCON0
+  {$SET_STATE_RAM '06C-07F:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '020-020:bnk0'} // INDF
+  {$SET_MAPPED_RAM '022-024:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '02B-02B:bnk0'} // INTCON0
+  {$SET_MAPPED_RAM '040-04B:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_MAPPED_RAM '060-060:bnk0'} // INDF
+  {$SET_MAPPED_RAM '062-064:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '06A-06A:bnk1'} // ANSEL
+  {$SET_MAPPED_RAM '06B-06B:bnk0'} // INTCON0
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '003:7F'} // STATUS
+  {$SET_UNIMP_BITS '004:7F'} // FSR
+  {$SET_UNIMP_BITS '006:3F'} // PORTA
+  {$SET_UNIMP_BITS '007:F0'} // PORTB
+  {$SET_UNIMP_BITS '00B:F1'} // INTCON0
+  {$SET_UNIMP_BITS '026:3F'} // EEADR
+  {$SET_UNIMP_BITS '065:F1'} // INTCON1
+  {$SET_UNIMP_BITS '066:7F'} // ISTATUS
+  {$SET_UNIMP_BITS '067:7F'} // IFSR
+  {$SET_UNIMP_BITS '068:03'} // IBSR
+  {$SET_UNIMP_BITS '069:03'} // OPACON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : VDD
+  // Pin  2 : RA5/OSC1/CLKIN
+  // Pin  3 : RA4/AN3/OSC2/CLKOUT
+  // Pin  4 : VPP/MCLR/RA3
+  // Pin  5 : RC5
+  // Pin  6 : RC4/C2OUT
+  // Pin  7 : RC3/AN7/OP1
+  // Pin  8 : RC6/OP1-
+  // Pin  9 : RC7/OP1+
+  // Pin 10 : RB7
+  // Pin 11 : RB6
+  // Pin 12 : RB5/OP2+
+  // Pin 13 : RB4/OP2-
+  // Pin 14 : RC2/AN6/OP2
+  // Pin 15 : RC1/AN5/C2IN-
+  // Pin 16 : RC0/AN4/C2IN+
+  // Pin 17 : RA2/AN2/C1OUT/T0CKI
+  // Pin 18 : RA1/AN1/C1IN-/CVREF/ICSPCLK
+  // Pin 19 : RA0/AN0/C1IN+/ICSPDAT
+  // Pin 20 : VSS
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '006:0-19,1-18,2-17,3-4,4-3,5-2'} // PORTA
+  {$MAP_RAM_TO_PIN '007:1-13,2-12,3-11,4-10'} // PORTB
+  {$MAP_RAM_TO_PIN '008:0-16,1-15,2-14,3-7,4-6,5-5,6-8,7-9'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DRTEN : Device Reset Timer Enable
+  {$define _DRTEN_ON          = $03FF}  // DRT Enabled (18 ms)
+  {$define _DRTEN_OFF         = $03FE}  // DRT Disabled
+
+  // BOREN : Brown-out Reset Enable
+  {$define _BOREN_ON          = $03FF}  // BOR Enabled
+  {$define _BOREN_OFF         = $03FD}  // BOR Disabled
+
+  // CPSW : Code Protection - Self Writable Memory
+  {$define _CPSW_OFF          = $03FF}  // Code protection off
+  {$define _CPSW_ON           = $03FB}  // Code protection on
+
+  // IOSCFS : Internal Oscillator Frequency Select
+  {$define _IOSCFS_8MHz       = $03FF}  // 8 MHz INTOSC Speed
+  {$define _IOSCFS_4MHz       = $03F7}  // 4 MHz INTOSC Speed
+
+  // MCLRE : Master Clear Enable
+  {$define _MCLRE_ON          = $03FF}  // MCLR pin functions as MCLR
+  {$define _MCLRE_OFF         = $03EF}  // MCLR pin functions as I/O, MCLR internally tied to Vdd
+
+  // CP : Code Protection - User Program Memory
+  {$define _CP_OFF            = $03FF}  // Code protection off
+  {$define _CP_ON             = $03DF}  // Code protection on
+
+  // WDTE : Watchdog Timer Enable
+  {$define _WDTE_ON           = $03FF}  // WDT Enabled
+  {$define _WDTE_OFF          = $03BF}  // WDT Disabled
+
+  // FOSC : Oscillator Selection
+  {$define _FOSC_LP           = $007F}  // LP oscillator and automatic 18 ms DRT (DRTEN ignored)
+  {$define _FOSC_XT           = $00FF}  // XT oscillator and automatic 18 ms DRT (DRTEN ignored)
+  {$define _FOSC_HS           = $017F}  // HS oscillator and automatic 18 ms DRT (DRTEN ignored)
+  {$define _FOSC_EC           = $01FF}  // EC oscillator with I/O function on OSC2/CLKOUT and 10 us startup time
+  {$define _FOSC_INTRC_IO     = $027F}  // INTRC with I/O function on OSC2/CLKOUT and 10 us startup time
+  {$define _FOSC_INTRC_CLKOUT = $02FF}  // INTRC with CLKOUT function on OSC2/CLKOUT and 10 us startup time
+  {$define _FOSC_EXTRC_IO     = $037F}  // EXTRC with I/O function on OSC2/CLKOUT and 10 us startup time
+  {$define _FOSC_EXTRC_CLKOUT = $03FF}  // EXTRC with CLKOUT function on OSC2/CLKOUT and 10 us startup time
+
+implementation
+end.

--- a/devices/PIC16F54.pas
+++ b/devices/PIC16F54.pas
@@ -1,0 +1,103 @@
+unit PIC16F54;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F54'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 18}
+{$SET PIC_NUMBANKS = 1}
+{$SET PIC_NUMPAGES = 1}
+{$SET PIC_MAXFLASH = 512}
+
+interface
+var
+  INDF        : byte absolute $0000;
+  TMR0        : byte absolute $0001;
+  PCL         : byte absolute $0002;
+  STATUS      : byte absolute $0003;
+  STATUS_PA2  : bit  absolute STATUS.7;
+  STATUS_PA1  : bit  absolute STATUS.6;
+  STATUS_PA0  : bit  absolute STATUS.5;
+  STATUS_TO   : bit  absolute STATUS.4;
+  STATUS_PD   : bit  absolute STATUS.3;
+  STATUS_Z    : bit  absolute STATUS.2;
+  STATUS_DC   : bit  absolute STATUS.1;
+  STATUS_C    : bit  absolute STATUS.0;
+  FSR         : byte absolute $0004;
+  PORTA       : byte absolute $0005;
+  PORTA_T0CKI : bit  absolute PORTA.4;
+  PORTA_RA3   : bit  absolute PORTA.3;
+  PORTA_RA2   : bit  absolute PORTA.2;
+  PORTA_RA1   : bit  absolute PORTA.1;
+  PORTA_RA0   : bit  absolute PORTA.0;
+  PORTB       : byte absolute $0006;
+  PORTB_RB7   : bit  absolute PORTB.7;
+  PORTB_RB6   : bit  absolute PORTB.6;
+  PORTB_RB5   : bit  absolute PORTB.5;
+  PORTB_RB4   : bit  absolute PORTB.4;
+  PORTB_RB3   : bit  absolute PORTB.3;
+  PORTB_RB2   : bit  absolute PORTB.2;
+  PORTB_RB1   : bit  absolute PORTB.1;
+  PORTB_RB0   : bit  absolute PORTB.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-006:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB
+  {$SET_STATE_RAM '007-01F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:1F'} // PORTA
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA2
+  // Pin  2 : RA3
+  // Pin  3 : T0CKI
+  // Pin  4 : MCLR/Vpp
+  // Pin  5 : VSS
+  // Pin  6 : RB0
+  // Pin  7 : RB1
+  // Pin  8 : RB2
+  // Pin  9 : RB3
+  // Pin 10 : RB4
+  // Pin 11 : RB5
+  // Pin 12 : RB6/ICSPCLK
+  // Pin 13 : RB7/ICSPDAT
+  // Pin 14 : VDD
+  // Pin 15 : OSC2/CLKOUT
+  // Pin 16 : OSC1/CLKIN
+  // Pin 17 : RA0
+  // Pin 18 : RA1
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-17,1-18,2-1,3-2,4-3'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+
+
+  // -- Bits Configuration --
+
+  // Reserved : Reserved
+  {$define _Reserved_ = $003F}  // 
+
+  // CP : Code protection bit
+  {$define _CP_OFF    = $004F}  // Code protection off
+  {$define _CP_ON     = $000F}  // Code protection on
+
+  // WDT : Watchdog timer enable bit
+  {$define _WDT_ON    = $008F}  // WDT enabled
+  {$define _WDT_OFF   = $000F}  // WDT disabled
+
+  // OSC : Oscillator selection bits
+  {$define _OSC_RC    = $030F}  // RC oscillator
+  {$define _OSC_HS    = $020F}  // HS oscillator
+  {$define _OSC_XT    = $010F}  // XT oscillator
+  {$define _OSC_LP    = $000F}  // LP oscillator
+
+implementation
+end.

--- a/devices/PIC16F57.pas
+++ b/devices/PIC16F57.pas
@@ -1,0 +1,123 @@
+unit PIC16F57;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F57'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 4}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF        : byte absolute $0000;
+  TMR0        : byte absolute $0001;
+  PCL         : byte absolute $0002;
+  STATUS      : byte absolute $0003;
+  STATUS_PA2  : bit  absolute STATUS.7;
+  STATUS_PA1  : bit  absolute STATUS.6;
+  STATUS_PA0  : bit  absolute STATUS.5;
+  STATUS_TO   : bit  absolute STATUS.4;
+  STATUS_PD   : bit  absolute STATUS.3;
+  STATUS_Z    : bit  absolute STATUS.2;
+  STATUS_DC   : bit  absolute STATUS.1;
+  STATUS_C    : bit  absolute STATUS.0;
+  FSR         : byte absolute $0004;
+  PORTA       : byte absolute $0005;
+  PORTA_T0CKI : bit  absolute PORTA.4;
+  PORTA_RA3   : bit  absolute PORTA.3;
+  PORTA_RA2   : bit  absolute PORTA.2;
+  PORTA_RA1   : bit  absolute PORTA.1;
+  PORTA_RA0   : bit  absolute PORTA.0;
+  PORTB       : byte absolute $0006;
+  PORTB_RB7   : bit  absolute PORTB.7;
+  PORTB_RB6   : bit  absolute PORTB.6;
+  PORTB_RB5   : bit  absolute PORTB.5;
+  PORTB_RB4   : bit  absolute PORTB.4;
+  PORTB_RB3   : bit  absolute PORTB.3;
+  PORTB_RB2   : bit  absolute PORTB.2;
+  PORTB_RB1   : bit  absolute PORTB.1;
+  PORTB_RB0   : bit  absolute PORTB.0;
+  PORTC       : byte absolute $0007;
+  PORTC_RC7   : bit  absolute PORTC.7;
+  PORTC_RC6   : bit  absolute PORTC.6;
+  PORTC_RC5   : bit  absolute PORTC.5;
+  PORTC_RC4   : bit  absolute PORTC.4;
+  PORTC_RC3   : bit  absolute PORTC.3;
+  PORTC_RC2   : bit  absolute PORTC.2;
+  PORTC_RC1   : bit  absolute PORTC.1;
+  PORTC_RC0   : bit  absolute PORTC.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-007:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC
+  {$SET_STATE_RAM '008-01F:GPR'} 
+  {$SET_STATE_RAM '028-03F:GPR'} 
+  {$SET_STATE_RAM '048-05F:GPR'} 
+  {$SET_STATE_RAM '068-07F:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:1F'} // PORTA
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : T0CKI
+  // Pin  2 : Vdd
+  // Pin  3 : N/C
+  // Pin  4 : Vss
+  // Pin  5 : N/C
+  // Pin  6 : RA0
+  // Pin  7 : RA1
+  // Pin  8 : RA2
+  // Pin  9 : RA3
+  // Pin 10 : RB0
+  // Pin 11 : RB1
+  // Pin 12 : RB2
+  // Pin 13 : RB3
+  // Pin 14 : RB4
+  // Pin 15 : RB5
+  // Pin 16 : RB6/ICSPCLK
+  // Pin 17 : RB7/ICSPDAT
+  // Pin 18 : RC0
+  // Pin 19 : RC1
+  // Pin 20 : RC2
+  // Pin 21 : RC3
+  // Pin 22 : RC4
+  // Pin 23 : RC5
+  // Pin 24 : RC6
+  // Pin 25 : RC7
+  // Pin 26 : OSC2/CLKOUT
+  // Pin 27 : OSC1/CLKIN
+  // Pin 28 : MCLR/Vpp
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-6,1-7,2-8,3-9,4-1'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-10,1-11,2-12,3-13,4-14,5-15,6-16,7-17'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-18,1-19,2-20,3-21,4-22,5-23,6-24,7-25'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // CP : Code protection bit
+  {$define _CP_OFF  = $000F}  // Code protection off
+  {$define _CP_ON   = $000E}  // Code protection on
+
+  // WDT : Watchdog timer enable bit
+  {$define _WDT_ON  = $000F}  // WDT enabled
+  {$define _WDT_OFF = $000D}  // WDT disabled
+
+  // OSC : Oscillator selection bits
+  {$define _OSC_RC  = $000F}  // RC oscillator
+  {$define _OSC_HS  = $000B}  // HS oscillator
+  {$define _OSC_XT  = $0007}  // XT oscillator
+  {$define _OSC_LP  = $0003}  // LP oscillator
+
+implementation
+end.

--- a/devices/PIC16F570.pas
+++ b/devices/PIC16F570.pas
@@ -1,0 +1,264 @@
+unit PIC16F570;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F570'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 28}
+{$SET PIC_NUMBANKS = 8}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF            : byte absolute $0000;
+  TMR0            : byte absolute $0001;
+  PCL             : byte absolute $0002;
+  STATUS          : byte absolute $0003;
+  STATUS_PA2      : bit  absolute STATUS.7;
+  STATUS_PA1      : bit  absolute STATUS.6;
+  STATUS_PA0      : bit  absolute STATUS.5;
+  STATUS_TO       : bit  absolute STATUS.4;
+  STATUS_PD       : bit  absolute STATUS.3;
+  STATUS_Z        : bit  absolute STATUS.2;
+  STATUS_DC       : bit  absolute STATUS.1;
+  STATUS_C        : bit  absolute STATUS.0;
+  FSR             : byte absolute $0004;
+  OSCCAL          : byte absolute $0005;
+  OSCCAL_CAL6     : bit  absolute OSCCAL.7;
+  OSCCAL_CAL5     : bit  absolute OSCCAL.6;
+  OSCCAL_CAL4     : bit  absolute OSCCAL.5;
+  OSCCAL_CAL3     : bit  absolute OSCCAL.4;
+  OSCCAL_CAL2     : bit  absolute OSCCAL.3;
+  OSCCAL_CAL1     : bit  absolute OSCCAL.2;
+  OSCCAL_CAL0     : bit  absolute OSCCAL.1;
+  PORTA           : byte absolute $0006;
+  PORTA_RA7       : bit  absolute PORTA.7;
+  PORTA_RA6       : bit  absolute PORTA.6;
+  PORTA_RA5       : bit  absolute PORTA.5;
+  PORTA_RA4       : bit  absolute PORTA.4;
+  PORTA_RA3       : bit  absolute PORTA.3;
+  PORTA_RA2       : bit  absolute PORTA.2;
+  PORTA_RA1       : bit  absolute PORTA.1;
+  PORTA_RA0       : bit  absolute PORTA.0;
+  PORTB           : byte absolute $0007;
+  PORTB_RB7       : bit  absolute PORTB.7;
+  PORTB_RB6       : bit  absolute PORTB.6;
+  PORTB_RB5       : bit  absolute PORTB.5;
+  PORTB_RB4       : bit  absolute PORTB.4;
+  PORTB_RB3       : bit  absolute PORTB.3;
+  PORTB_RB2       : bit  absolute PORTB.2;
+  PORTB_RB1       : bit  absolute PORTB.1;
+  PORTB_RB0       : bit  absolute PORTB.0;
+  PORTC           : byte absolute $0008;
+  PORTC_RC7       : bit  absolute PORTC.7;
+  PORTC_RC6       : bit  absolute PORTC.6;
+  PORTC_RC5       : bit  absolute PORTC.5;
+  PORTC_RC4       : bit  absolute PORTC.4;
+  PORTC_RC3       : bit  absolute PORTC.3;
+  PORTC_RC2       : bit  absolute PORTC.2;
+  PORTC_RC1       : bit  absolute PORTC.1;
+  PORTC_RC0       : bit  absolute PORTC.0;
+  ADCON0          : byte absolute $0009;
+  ADCON0_ADCS1    : bit  absolute ADCON0.7;
+  ADCON0_ADCS0    : bit  absolute ADCON0.6;
+  ADCON0_CHS3     : bit  absolute ADCON0.5;
+  ADCON0_CHS2     : bit  absolute ADCON0.4;
+  ADCON0_CHS1     : bit  absolute ADCON0.3;
+  ADCON0_CHS0     : bit  absolute ADCON0.2;
+  ADCON0_GO_nDONE : bit  absolute ADCON0.1;
+  ADCON0_ADON     : bit  absolute ADCON0.0;
+  ADRES           : byte absolute $000A;
+  ADRES_ADRES7    : bit  absolute ADRES.7;
+  ADRES_ADRES6    : bit  absolute ADRES.6;
+  ADRES_ADRES5    : bit  absolute ADRES.5;
+  ADRES_ADRES4    : bit  absolute ADRES.4;
+  ADRES_ADRES3    : bit  absolute ADRES.3;
+  ADRES_ADRES2    : bit  absolute ADRES.2;
+  ADRES_ADRES1    : bit  absolute ADRES.1;
+  ADRES_ADRES0    : bit  absolute ADRES.0;
+  INTCON0         : byte absolute $000B;
+  INTCON0_ADIF    : bit  absolute INTCON0.7;
+  INTCON0_CWIF    : bit  absolute INTCON0.6;
+  INTCON0_T0IF    : bit  absolute INTCON0.5;
+  INTCON0_RBIF    : bit  absolute INTCON0.4;
+  INTCON0_GIE     : bit  absolute INTCON0.3;
+  EECON           : byte absolute $0021;
+  EECON_FREE      : bit  absolute EECON.4;
+  EECON_WRERR     : bit  absolute EECON.3;
+  EECON_WREN      : bit  absolute EECON.2;
+  EECON_WR        : bit  absolute EECON.1;
+  EECON_RD        : bit  absolute EECON.0;
+  EEDATA          : byte absolute $0025;
+  EEADR           : byte absolute $0026;
+  CM1CON0         : byte absolute $0027;
+  CM1CON0_C1OUT   : bit  absolute CM1CON0.7;
+  CM1CON0_C1OUTEN : bit  absolute CM1CON0.6;
+  CM1CON0_C1POL   : bit  absolute CM1CON0.5;
+  CM1CON0_C1T0CS  : bit  absolute CM1CON0.4;
+  CM1CON0_C1ON    : bit  absolute CM1CON0.3;
+  CM1CON0_C1NREF  : bit  absolute CM1CON0.2;
+  CM1CON0_C1PREF  : bit  absolute CM1CON0.1;
+  CM1CON0_C1WU    : bit  absolute CM1CON0.0;
+  CM2CON0         : byte absolute $0028;
+  CM2CON0_C2OUT   : bit  absolute CM2CON0.7;
+  CM2CON0_C2OUTEN : bit  absolute CM2CON0.6;
+  CM2CON0_C2POL   : bit  absolute CM2CON0.5;
+  CM2CON0_C2PREF2 : bit  absolute CM2CON0.4;
+  CM2CON0_C2ON    : bit  absolute CM2CON0.3;
+  CM2CON0_C2NREF  : bit  absolute CM2CON0.2;
+  CM2CON0_C2PREF1 : bit  absolute CM2CON0.1;
+  CM2CON0_C2WU    : bit  absolute CM2CON0.0;
+  VRCON           : byte absolute $0029;
+  VRCON_VREN      : bit  absolute VRCON.7;
+  VRCON_VROE1     : bit  absolute VRCON.6;
+  VRCON_VROE2     : bit  absolute VRCON.5;
+  VRCON_VRR       : bit  absolute VRCON.4;
+  VRCON_VR3       : bit  absolute VRCON.3;
+  VRCON_VR2       : bit  absolute VRCON.2;
+  VRCON_VR1       : bit  absolute VRCON.1;
+  VRCON_VR0       : bit  absolute VRCON.0;
+  ANSEL           : byte absolute $002A;
+  ANSEL_ANS7      : bit  absolute ANSEL.7;
+  ANSEL_ANS6      : bit  absolute ANSEL.6;
+  ANSEL_ANS5      : bit  absolute ANSEL.5;
+  ANSEL_ANS4      : bit  absolute ANSEL.4;
+  ANSEL_ANS3      : bit  absolute ANSEL.3;
+  ANSEL_ANS2      : bit  absolute ANSEL.2;
+  ANSEL_ANS1      : bit  absolute ANSEL.1;
+  ANSEL_ANS0      : bit  absolute ANSEL.0;
+  IW              : byte absolute $0061;
+  INTCON1         : byte absolute $0065;
+  INTCON1_ADIE    : bit  absolute INTCON1.7;
+  INTCON1_CWIE    : bit  absolute INTCON1.6;
+  INTCON1_T0IE    : bit  absolute INTCON1.5;
+  INTCON1_RBIE    : bit  absolute INTCON1.4;
+  INTCON1_WUR     : bit  absolute INTCON1.3;
+  ISTATUS         : byte absolute $0066;
+  IFSR            : byte absolute $0067;
+  IBSR            : byte absolute $0068;
+  OPACON          : byte absolute $0069;
+  OPACON_OPA2ON   : bit  absolute OPACON.1;
+  OPACON_OPA1ON   : bit  absolute OPACON.0;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-00B:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_STATE_RAM '00C-01F:GPR'} 
+  {$SET_STATE_RAM '020-02B:SFR'}  // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR, CM1CON0, CM2CON0, VRCON, ANSEL, INTCON0
+  {$SET_STATE_RAM '02C-03F:GPR'} 
+  {$SET_STATE_RAM '040-04B:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_STATE_RAM '04C-05F:GPR'} 
+  {$SET_STATE_RAM '060-06B:SFR'}  // INDF, IW, PCL, STATUS, FSR, INTCON1, ISTATUS, IFSR, IBSR, OPACON, ANSEL, INTCON0
+  {$SET_STATE_RAM '06C-07F:GPR'} 
+  {$SET_STATE_RAM '080-08B:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_STATE_RAM '08C-09F:GPR'} 
+  {$SET_STATE_RAM '0A0-0AB:SFR'}  // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR, CM1CON0, CM2CON0, VRCON, ANSEL, INTCON0
+  {$SET_STATE_RAM '0AC-0BF:GPR'} 
+  {$SET_STATE_RAM '0C0-0CB:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_STATE_RAM '0CC-0DF:GPR'} 
+  {$SET_STATE_RAM '0E0-0EB:SFR'}  // INDF, IW, PCL, STATUS, FSR, INTCON1, ISTATUS, IFSR, IBSR, OPACON, ANSEL, INTCON0
+  {$SET_STATE_RAM '0EC-0FF:GPR'} 
+
+
+  // -- Define mirrored registers --
+
+  {$SET_MAPPED_RAM '020-020:bnk0'} // INDF
+  {$SET_MAPPED_RAM '022-024:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '02B-02B:bnk0'} // INTCON0
+  {$SET_MAPPED_RAM '040-04B:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_MAPPED_RAM '060-060:bnk0'} // INDF
+  {$SET_MAPPED_RAM '062-064:bnk0'} // PCL, STATUS, FSR
+  {$SET_MAPPED_RAM '06A-06B:bnk1'} // ANSEL, INTCON0
+  {$SET_MAPPED_RAM '080-08B:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_MAPPED_RAM '0A0-0AB:bnk1'} // INDF, EECON, PCL, STATUS, FSR, EEDATA, EEADR, CM1CON0, CM2CON0, VRCON, ANSEL, INTCON0
+  {$SET_MAPPED_RAM '0C0-0CB:bnk0'} // INDF, TMR0, PCL, STATUS, FSR, OSCCAL, PORTA, PORTB, PORTC, ADCON0, ADRES, INTCON0
+  {$SET_MAPPED_RAM '0E0-0EB:bnk3'} // INDF, IW, PCL, STATUS, FSR, INTCON1, ISTATUS, IFSR, IBSR, OPACON, ANSEL, INTCON0
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '00B:F1'} // INTCON0
+  {$SET_UNIMP_BITS '026:3F'} // EEADR
+  {$SET_UNIMP_BITS '065:F1'} // INTCON1
+  {$SET_UNIMP_BITS '068:07'} // IBSR
+  {$SET_UNIMP_BITS '069:03'} // OPACON
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : VPP/MCLR
+  // Pin  2 : RA0/AN0
+  // Pin  3 : RA1/AN1/C1IN+
+  // Pin  4 : RA2/AN2/CVREF1
+  // Pin  5 : RA3/AN3/C2IN+
+  // Pin  6 : RA4/AN4/T0CKI
+  // Pin  7 : RA5/AN5
+  // Pin  8 : VSS
+  // Pin  9 : RA7/CLKIN/OSC1
+  // Pin 10 : RA6/CLKOUT/OSC2
+  // Pin 11 : RC0
+  // Pin 12 : RC1/AN6/OPA1OUT
+  // Pin 13 : RC2/OPA1IN-
+  // Pin 14 : RC3/OPA1IN+
+  // Pin 15 : RC4/OPA2IN+
+  // Pin 16 : RC5/OPA2IN-
+  // Pin 17 : RC6/AN7/OPA2OUT
+  // Pin 18 : RC7/C2IN-
+  // Pin 19 : VSS
+  // Pin 20 : VDD
+  // Pin 21 : RB0
+  // Pin 22 : RB1
+  // Pin 23 : RB2
+  // Pin 24 : RB3/C1OUT
+  // Pin 25 : RB4/C2OUT
+  // Pin 26 : RB5
+  // Pin 27 : RB6/ICSPCLK
+  // Pin 28 : RB7/ICSPDAT/C1IN-/CVREF2
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '006:0-2,1-3,2-4,3-5,4-6,5-7,6-10,7-9'} // PORTA
+  {$MAP_RAM_TO_PIN '007:0-21,1-22,2-23,3-24,4-25,5-26,6-27,7-28'} // PORTB
+  {$MAP_RAM_TO_PIN '008:0-11,1-12,2-13,3-14,4-15,5-16,6-17,7-18'} // PORTC
+
+
+  // -- Bits Configuration --
+
+  // DRTEN : 
+  {$define _DRTEN_ON          = $03DF}  // DRT Enabled
+  {$define _DRTEN_OFF         = $03DE}  // DRT Disabled
+
+  // BOREN : 
+  {$define _BOREN_ON          = $03DF}  // BOR Enabled
+  {$define _BOREN_OFF         = $03DD}  // BOR Disabled
+
+  // CPSW : Code Protection bit - Flash Data Memory
+  {$define _CPSW_OFF          = $03DF}  // Code protection off
+  {$define _CPSW_ON           = $03DB}  // Code protection on
+
+  // IOSCFS : Internal Oscillator Frequency Select
+  {$define _IOSCFS_8MHz       = $03DF}  // 8 MHz INTOSC Speed
+  {$define _IOSCFS_4MHz       = $03D7}  // 4 MHz INTOSC Speed
+
+  // CP : Code Protection bit
+  {$define _CP_OFF            = $03DF}  // Code protection off
+  {$define _CP_ON             = $03CF}  // Code protection on
+
+  // WDTE : Watchdog Timer Enable bit
+  {$define _WDTE_ON           = $03FF}  // Enabled
+  {$define _WDTE_OFF          = $03DF}  // Disabled
+
+  // FOSC : Oscillator
+  {$define _FOSC_LP           = $021F}  // LP oscillator and 18 ms DRT
+  {$define _FOSC_XT           = $025F}  // XT oscillator and 18 ms DRT
+  {$define _FOSC_HS           = $029F}  // HS oscillator and 18 ms DRT
+  {$define _FOSC_EC           = $02DF}  // EC oscillator with I/O function on OSC2/CLKOUT
+  {$define _FOSC_INTRC_IO     = $031F}  // INTRC with I/O function on OSC2/CLKOUT
+  {$define _FOSC_INTRC_CLKOUT = $035F}  // INTRC with CLKOUT function on OSC2/CLKOUT
+  {$define _FOSC_EXTRC_IO     = $039F}  // EXTRC with I/O function on OSC2/CLKOUT
+  {$define _FOSC_EXTRC_CLKOUT = $03DF}  // EXTRC with CLKOUT function on OSC2/CLKOUT
+
+implementation
+end.

--- a/devices/PIC16F59.pas
+++ b/devices/PIC16F59.pas
@@ -1,0 +1,156 @@
+unit PIC16F59;
+
+// Define hardware
+{$SET PIC_MODEL    = 'PIC16F59'}
+{$SET PIC_MAXFREQ  = 20000000}
+{$SET PIC_NPINS    = 40}
+{$SET PIC_NUMBANKS = 8}
+{$SET PIC_NUMPAGES = 4}
+{$SET PIC_MAXFLASH = 2048}
+
+interface
+var
+  INDF        : byte absolute $0000;
+  TMR0        : byte absolute $0001;
+  PCL         : byte absolute $0002;
+  STATUS      : byte absolute $0003;
+  STATUS_PA2  : bit  absolute STATUS.7;
+  STATUS_PA1  : bit  absolute STATUS.6;
+  STATUS_PA0  : bit  absolute STATUS.5;
+  STATUS_TO   : bit  absolute STATUS.4;
+  STATUS_PD   : bit  absolute STATUS.3;
+  STATUS_Z    : bit  absolute STATUS.2;
+  STATUS_DC   : bit  absolute STATUS.1;
+  STATUS_C    : bit  absolute STATUS.0;
+  FSR         : byte absolute $0004;
+  PORTA       : byte absolute $0005;
+  PORTA_T0CKI : bit  absolute PORTA.4;
+  PORTA_RA3   : bit  absolute PORTA.3;
+  PORTA_RA2   : bit  absolute PORTA.2;
+  PORTA_RA1   : bit  absolute PORTA.1;
+  PORTA_RA0   : bit  absolute PORTA.0;
+  PORTB       : byte absolute $0006;
+  PORTB_RB7   : bit  absolute PORTB.7;
+  PORTB_RB6   : bit  absolute PORTB.6;
+  PORTB_RB5   : bit  absolute PORTB.5;
+  PORTB_RB4   : bit  absolute PORTB.4;
+  PORTB_RB3   : bit  absolute PORTB.3;
+  PORTB_RB2   : bit  absolute PORTB.2;
+  PORTB_RB1   : bit  absolute PORTB.1;
+  PORTB_RB0   : bit  absolute PORTB.0;
+  PORTC       : byte absolute $0007;
+  PORTC_RC7   : bit  absolute PORTC.7;
+  PORTC_RC6   : bit  absolute PORTC.6;
+  PORTC_RC5   : bit  absolute PORTC.5;
+  PORTC_RC4   : bit  absolute PORTC.4;
+  PORTC_RC3   : bit  absolute PORTC.3;
+  PORTC_RC2   : bit  absolute PORTC.2;
+  PORTC_RC1   : bit  absolute PORTC.1;
+  PORTC_RC0   : bit  absolute PORTC.0;
+  PORTD       : byte absolute $0008;
+  PORTD_RD7   : bit  absolute PORTD.7;
+  PORTD_RD6   : bit  absolute PORTD.6;
+  PORTD_RD5   : bit  absolute PORTD.5;
+  PORTD_RD4   : bit  absolute PORTD.4;
+  PORTD_RD3   : bit  absolute PORTD.3;
+  PORTD_RD2   : bit  absolute PORTD.2;
+  PORTD_RD1   : bit  absolute PORTD.1;
+  PORTD_RD0   : bit  absolute PORTD.0;
+  PORTE       : byte absolute $0009;
+  PORTE_RE7   : bit  absolute PORTE.7;
+  PORTE_RE6   : bit  absolute PORTE.6;
+  PORTE_RE5   : bit  absolute PORTE.5;
+  PORTE_RE4   : bit  absolute PORTE.4;
+
+
+  // -- Define RAM state values --
+
+  {$SET_STATE_RAM '000-009:SFR'}  // INDF, TMR0, PCL, STATUS, FSR, PORTA, PORTB, PORTC, PORTD, PORTE
+  {$SET_STATE_RAM '00A-01F:GPR'} 
+  {$SET_STATE_RAM '02A-03F:GPR'} 
+  {$SET_STATE_RAM '04A-05F:GPR'} 
+  {$SET_STATE_RAM '06A-07F:GPR'} 
+  {$SET_STATE_RAM '08A-09F:GPR'} 
+  {$SET_STATE_RAM '0AA-0BF:GPR'} 
+  {$SET_STATE_RAM '0CA-0DF:GPR'} 
+  {$SET_STATE_RAM '0EA-0FF:GPR'} 
+
+
+  // -- Initial values --
+
+  {$SET_UNIMP_BITS '000:00'} // INDF
+  {$SET_UNIMP_BITS '005:1F'} // PORTA
+  {$SET_UNIMP_BITS '009:F0'} // PORTE
+
+
+  // -- PIN mapping --
+
+  // Pin  1 : RA0
+  // Pin  2 : RA1
+  // Pin  3 : RA2
+  // Pin  4 : RA3
+  // Pin  5 : Vss
+  // Pin  6 : RB0
+  // Pin  7 : RB1
+  // Pin  8 : RB2
+  // Pin  9 : RB3
+  // Pin 10 : RB4
+  // Pin 11 : RB5
+  // Pin 12 : RB6/ICSPCLK
+  // Pin 13 : RB7/ICSPDAT
+  // Pin 14 : MCLR/Vpp
+  // Pin 15 : Vdd
+  // Pin 16 : RC0
+  // Pin 17 : RC1
+  // Pin 18 : RC2
+  // Pin 19 : RC3
+  // Pin 20 : RC4
+  // Pin 21 : RC5
+  // Pin 22 : RC6
+  // Pin 23 : RC7
+  // Pin 24 : RD0
+  // Pin 25 : Vss
+  // Pin 26 : RD1
+  // Pin 27 : RD2
+  // Pin 28 : RD3
+  // Pin 29 : RD4
+  // Pin 30 : RD5
+  // Pin 31 : RD6
+  // Pin 32 : RD7
+  // Pin 33 : OSC2/CLKOUT
+  // Pin 34 : OSC1/CLKIN
+  // Pin 35 : Vdd
+  // Pin 36 : RE4
+  // Pin 37 : RE5
+  // Pin 38 : RE6
+  // Pin 39 : RE7
+  // Pin 40 : T0CKI
+
+
+  // -- RAM to PIN mapping --
+
+  {$MAP_RAM_TO_PIN '005:0-1,1-2,2-3,3-4,4-40'} // PORTA
+  {$MAP_RAM_TO_PIN '006:0-6,1-7,2-8,3-9,4-10,5-11,6-12,7-13'} // PORTB
+  {$MAP_RAM_TO_PIN '007:0-16,1-17,2-18,3-19,4-20,5-21,6-22,7-23'} // PORTC
+  {$MAP_RAM_TO_PIN '008:0-24,1-26,2-27,3-28,4-29,5-30,6-31,7-32'} // PORTD
+  {$MAP_RAM_TO_PIN '009:4-36,5-37,6-38,7-39'} // PORTE
+
+
+  // -- Bits Configuration --
+
+  // CP : Code protection bit
+  {$define _CP_OFF  = $000F}  // Code protection off
+  {$define _CP_ON   = $000E}  // Code protection on
+
+  // WDT : Watchdog timer enable bit
+  {$define _WDT_ON  = $000F}  // WDT enabled
+  {$define _WDT_OFF = $000D}  // WDT disabled
+
+  // OSC : Oscillator selection bits
+  {$define _OSC_RC  = $000F}  // RC oscillator
+  {$define _OSC_HS  = $000B}  // HS oscillator
+  {$define _OSC_XT  = $0007}  // XT oscillator
+  {$define _OSC_LP  = $0003}  // LP oscillator
+
+implementation
+end.


### PR DESCRIPTION
List of added PIC Baseline models:

PIC10:
PIC10F200 PIC10F202 PIC10F204 PIC10F206 PIC10F220 PIC10F222 

PIC12:
PIC12F508 PIC12F509 PIC12F510 PIC12F519 

PIC16:
PIC16F54 PIC16F57 PIC16F59 PIC16F505 PIC16F506 PIC16F526 PIC16F527 PIC16F570 